### PR TITLE
refactor: capture generic type info only for boxes, global and local states

### DIFF
--- a/src/test-execution-context.ts
+++ b/src/test-execution-context.ts
@@ -64,7 +64,6 @@ export class TestExecutionContext implements internal.ExecutionContext {
     this.txn.appendLog(value)
   }
 
-  /* @internal */
   exportLogs<const T extends [...LogDecoding[]]>(appId: uint64, ...decoding: T): DecodedLogs<T> {
     return this.txn.exportLogs(appId, ...decoding)
   }

--- a/src/test-transformer/node-factory.ts
+++ b/src/test-transformer/node-factory.ts
@@ -94,19 +94,17 @@ export const nodeFactory = {
     )
   },
 
-  callStubbedFunction(functionName: string, node: ts.CallExpression, ...typeInfos: (TypeInfo | undefined)[]) {
-    const infoStringArray = typeInfos.length ? typeInfos.map((typeInfo) => JSON.stringify(typeInfo)) : undefined
+  callStubbedFunction(functionName: string, node: ts.CallExpression, typeInfo?: TypeInfo) {
+    const typeInfoArg = typeInfo ? factory.createStringLiteral(JSON.stringify(typeInfo)) : undefined
     const updatedPropertyAccessExpression = factory.createPropertyAccessExpression(
       factory.createIdentifier('runtimeHelpers'),
       `${functionName}Impl`,
     )
-    const typeInfoArgs = infoStringArray
-      ? infoStringArray?.filter((s) => !!s).map((infoString) => factory.createStringLiteral(infoString))
-      : undefined
+
     return factory.createCallExpression(
       updatedPropertyAccessExpression,
       node.typeArguments,
-      [...(typeInfoArgs ?? []), ...(node.arguments ?? [])].filter((arg) => !!arg),
+      [typeInfoArg, ...(node.arguments ?? [])].filter((arg) => !!arg),
     )
   },
 } satisfies Record<string, (...args: DeliberateAny[]) => ts.Node>


### PR DESCRIPTION
refactor: 
- capture generic type info only for boxes, global states, and local states as type info is not needed for others
- capture stubbed function name as private property to prevent extra calls to get function name
- change type info param passed to `callStubbedFunction` in `nodeFactory` from array to a single item as it is always a single type info