### PR TITLE
refactor: remove avm version check as algod latest image is now v4

### DIFF
--- a/tests/arc4/address.spec.ts
+++ b/tests/arc4/address.spec.ts
@@ -14,31 +14,31 @@ const testData = [
   Bytes.fromHex(`${'00'.repeat(31)}ff`),
 ]
 
-describe('arc4.Address', async () => {
+describe('arc4.Address', () => {
   const ctx = new TestExecutionContext()
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 
-  test.each(testData)('create address from bytes', async (value) => {
+  test.each(testData)('create address from bytes', (value) => {
     const sdkResult = getABIEncodedValue(asUint8Array(value), abiTypeString, {})
     const result = new Address(value)
     expect(result.bytes).toEqual(sdkResult)
   })
-  test.each(testData)('create address from str', async (value) => {
+  test.each(testData)('create address from str', (value) => {
     const stringValue = encodeAddress(asUint8Array(value))
     const sdkResult = getABIEncodedValue(stringValue, abiTypeString, {})
     const result = new Address(stringValue)
     expect(result.bytes).toEqual(sdkResult)
   })
-  test.each(testData)('create address from Account', async (value) => {
+  test.each(testData)('create address from Account', (value) => {
     const accountValue = Account(value)
     const sdkResult = getABIEncodedValue(asUint8Array(accountValue.bytes), abiTypeString, {})
     const result = new Address(accountValue)
     expect(result.bytes).toEqual(sdkResult)
   })
 
-  test.each(testData)('get item from address created from bytes', async (value) => {
+  test.each(testData)('get item from address created from bytes', (value) => {
     const uint8ArrayValue = asUint8Array(value)
     const result = new Address(value)
     let i = 0
@@ -47,7 +47,7 @@ describe('arc4.Address', async () => {
     }
     expect(result.length).toEqual(uint8ArrayValue.length)
   })
-  test.each(testData)('get item from address created from str', async (value) => {
+  test.each(testData)('get item from address created from str', (value) => {
     const uint8ArrayValue = asUint8Array(value)
     const stringValue = encodeAddress(uint8ArrayValue)
     const result = new Address(stringValue)
@@ -57,7 +57,7 @@ describe('arc4.Address', async () => {
     }
     expect(result.length).toEqual(uint8ArrayValue.length)
   })
-  test.each(testData)('get item from address created from Account', async (value) => {
+  test.each(testData)('get item from address created from Account', (value) => {
     const uint8ArrayValue = asUint8Array(value)
     const accountValue = Account(value)
     const result = new Address(accountValue)
@@ -68,13 +68,13 @@ describe('arc4.Address', async () => {
     expect(result.length).toEqual(uint8ArrayValue.length)
   })
 
-  test.each(testData)('fromBytes method', async (value) => {
+  test.each(testData)('fromBytes method', (value) => {
     const sdkResult = getABIEncodedValue(asUint8Array(value), abiTypeString, {})
     const result = interpretAsArc4<Address>(value)
     expect(result.bytes).toEqual(sdkResult)
   })
 
-  test.each(testData)('fromLog method', async (value) => {
+  test.each(testData)('fromLog method', (value) => {
     const sdkResult = getABIEncodedValue(asUint8Array(value), abiTypeString, {})
     const paddedValue = Bytes([...asUint8Array(ABI_RETURN_VALUE_LOG_PREFIX), ...asUint8Array(value)])
     const result = interpretAsArc4<Address>(paddedValue, 'log')

--- a/tests/arc4/bool.spec.ts
+++ b/tests/arc4/bool.spec.ts
@@ -12,7 +12,7 @@ describe('arc4.Bool', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/arc4/byte.spec.ts
+++ b/tests/arc4/byte.spec.ts
@@ -14,7 +14,7 @@ describe('arc4.Byte', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/arc4/dynamic-array.spec.ts
+++ b/tests/arc4/dynamic-array.spec.ts
@@ -333,9 +333,9 @@ const structDynamicArray = {
   },
 }
 
-describe('arc4.DynamicArray', async () => {
+describe('arc4.DynamicArray', () => {
   const ctx = new TestExecutionContext()
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 
@@ -353,7 +353,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('should be able to get bytes representation', async (data) => {
+  ])('should be able to get bytes representation', (data) => {
     const sdkResult = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const result = data.array().bytes
     expect(result).toEqual(sdkResult)
@@ -373,7 +373,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('copy dynamic array', async (data) => {
+  ])('copy dynamic array', (data) => {
     const sdkResult = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const original = data.array()
     const copy = original.copy()
@@ -396,7 +396,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('get item from dynamic array', async (data) => {
+  ])('get item from dynamic array', (data) => {
     const dynamicArray = data.array()
     const nativeValues = data.nativeValues()
     for (let i = 0; i < dynamicArray.length; i++) {
@@ -419,7 +419,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('set item in dynamic array', async (data) => {
+  ])('set item in dynamic array', (data) => {
     const nativeValues = data.nativeValues()
     const nativeValuesCopy = [...nativeValues]
     const nativeTemp = nativeValuesCopy.at(-1)!
@@ -451,7 +451,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('create dynamic array from bytes', async (data) => {
+  ])('create dynamic array from bytes', (data) => {
     const sdkEncodedBytes = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const result = data.create(Bytes(sdkEncodedBytes))
     const nativeValues = data.nativeValues()
@@ -474,7 +474,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('push item to dynamic array', async (data) => {
+  ])('push item to dynamic array', (data) => {
     const nativeValues = data.nativeValues()
     const nativeValuesCopy = [...nativeValues]
     nativeValuesCopy.push(nativeValues.at(-1)!)
@@ -503,7 +503,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('push item to empty dynamic array', async (data) => {
+  ])('push item to empty dynamic array', (data) => {
     const nativeValues = data.nativeValues()
     const sdkResult = getABIEncodedValue(nativeValues, data.abiTypeString, {})
 
@@ -527,7 +527,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('push item to empty dynamic array created from bytes', async (data) => {
+  ])('push item to empty dynamic array created from bytes', (data) => {
     const nativeValues = data.nativeValues()
     const sdkResult = getABIEncodedValue(nativeValues, data.abiTypeString, {})
 
@@ -551,7 +551,7 @@ describe('arc4.DynamicArray', async () => {
     stringDynamicArrayOfArrayOfArray,
     tupleDynamicArray,
     structDynamicArray,
-  ])('pop item from dynamic array', async (data) => {
+  ])('pop item from dynamic array', (data) => {
     const nativeValues = data.nativeValues()
     const nativeValuesCopy = [...nativeValues]
     const nativeValue1 = nativeValuesCopy.pop()
@@ -570,7 +570,7 @@ describe('arc4.DynamicArray', async () => {
     expect(result).toEqual(Bytes(sdkResult))
   })
 
-  it('set item in nested dynamic array', async () => {
+  it('set item in nested dynamic array', () => {
     const data = stringDynamicArrayOfArrayOfArray
     const nativeValues = data.nativeValues()
     nativeValues[0][0][0] = 'new value'
@@ -583,7 +583,7 @@ describe('arc4.DynamicArray', async () => {
     expect(result).toEqual(Bytes(sdkResult))
   })
 
-  it('set item in nested dynamic array created from bytes', async () => {
+  it('set item in nested dynamic array created from bytes', () => {
     const data = stringDynamicArrayOfArrayOfArray
     const nativeValues = data.nativeValues()
     nativeValues[0][0][0] = 'new value'

--- a/tests/arc4/emit.spec.ts
+++ b/tests/arc4/emit.spec.ts
@@ -44,7 +44,7 @@ describe('arc4.emit', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/arc4/static-array.spec.ts
+++ b/tests/arc4/static-array.spec.ts
@@ -320,9 +320,9 @@ const structStaticArray = {
   },
 }
 
-describe('arc4.StaticArray', async () => {
+describe('arc4.StaticArray', () => {
   const ctx = new TestExecutionContext()
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 
@@ -340,7 +340,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('should be able to get bytes representation', async (data) => {
+  ])('should be able to get bytes representation', (data) => {
     const sdkResult = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const result = data.array().bytes
     expect(result).toEqual(Bytes(sdkResult))
@@ -360,7 +360,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('copy static array', async (data) => {
+  ])('copy static array', (data) => {
     const sdkResult = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const original = data.array()
     const copy = original.copy()
@@ -383,7 +383,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('get item from static array', async (data) => {
+  ])('get item from static array', (data) => {
     const staticArray = data.array()
     const nativeValues = data.nativeValues()
     for (let i = 0; i < staticArray.length; i++) {
@@ -406,7 +406,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('set item in static array', async (data) => {
+  ])('set item in static array', (data) => {
     const nativeValues = data.nativeValues()
     const nativeValuesCopy = [...nativeValues]
     const nativeTemp = nativeValuesCopy.at(-1)!
@@ -438,7 +438,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('create static array from bytes', async (data) => {
+  ])('create static array from bytes', (data) => {
     const sdkEncodedBytes = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const result = data.create(Bytes(sdkEncodedBytes))
     const nativeValues = data.nativeValues()
@@ -461,7 +461,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('get item from static array created from bytes', async (data) => {
+  ])('get item from static array created from bytes', (data) => {
     const nativeValues = data.nativeValues()
     const sdkEncodedBytes = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const staticArray = data.create(Bytes(sdkEncodedBytes))
@@ -485,7 +485,7 @@ describe('arc4.StaticArray', async () => {
     stringStaticArrayOfArrayOfArray,
     tupleStaticArray,
     structStaticArray,
-  ])('set item in static array created from bytes', async (data) => {
+  ])('set item in static array created from bytes', (data) => {
     const nativeValues = data.nativeValues()
     const nativeValuesCopy = [...nativeValues]
     const nativeTemp = nativeValuesCopy.at(-1)!
@@ -504,7 +504,7 @@ describe('arc4.StaticArray', async () => {
     expect(result).toEqual(Bytes(sdkResult))
   })
 
-  it('set item in nested static array', async () => {
+  it('set item in nested static array', () => {
     const data = stringStaticArrayOfArrayOfArray
     const nativeValues = data.nativeValues()
     nativeValues[0][0][0] = 'new value'
@@ -517,7 +517,7 @@ describe('arc4.StaticArray', async () => {
     expect(result).toEqual(Bytes(sdkResult))
   })
 
-  it('set item in nested static array create from bytes', async () => {
+  it('set item in nested static array create from bytes', () => {
     const data = stringStaticArrayOfArrayOfArray
     const nativeValues = data.nativeValues()
     nativeValues[0][0][0] = 'new value'

--- a/tests/arc4/str.spec.ts
+++ b/tests/arc4/str.spec.ts
@@ -13,7 +13,7 @@ describe('arc4.Str', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/arc4/tuple.spec.ts
+++ b/tests/arc4/tuple.spec.ts
@@ -291,19 +291,19 @@ const testDataWithArray = [
   },
 ]
 
-describe('arc4.Tuple', async () => {
+describe('arc4.Tuple', () => {
   const ctx = new TestExecutionContext()
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 
-  test.each(testData)('should be able to get bytes representation', async (data) => {
+  test.each(testData)('should be able to get bytes representation', (data) => {
     const sdkResult = getABIEncodedValue(data.nativeValues(), data.abiTypeString, {})
     const result = data.tuple().bytes
     expect(result).toEqual(Bytes(sdkResult))
   })
 
-  test.each(testData)('should be able to get native representation', async (data) => {
+  test.each(testData)('should be able to get native representation', (data) => {
     const nativeValues = data.nativeValues()
     const result = data.tuple().native
     for (let i = 0; i < nativeValues.length; i++) {
@@ -312,7 +312,7 @@ describe('arc4.Tuple', async () => {
     expect(result.length).toEqual(nativeValues.length)
   })
 
-  test.each(testData)('create tuple from bytes', async (data) => {
+  test.each(testData)('create tuple from bytes', (data) => {
     const nativeValues = data.nativeValues()
     const sdkEncodedBytes = getABIEncodedValue(nativeValues, data.abiTypeString, {})
 
@@ -324,7 +324,7 @@ describe('arc4.Tuple', async () => {
     }
   })
 
-  test.each(testDataWithArray)('update array values in tuple', async (data) => {
+  test.each(testDataWithArray)('update array values in tuple', (data) => {
     const sdkResult = getABIEncodedValue(data.updatedNativeValues(), data.abiTypeString, {})
     const tuple = data.tuple()
     data.update(tuple as DeliberateAny)

--- a/tests/arc4/ufixednxm.spec.ts
+++ b/tests/arc4/ufixednxm.spec.ts
@@ -14,7 +14,7 @@ describe('arc4.UFixedNxM', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/arc4/uintn.spec.ts
+++ b/tests/arc4/uintn.spec.ts
@@ -14,7 +14,7 @@ describe('arc4.UintN', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/avm-invoker.ts
+++ b/tests/avm-invoker.ts
@@ -22,14 +22,6 @@ const algorandClient = Lazy(() => {
 
 export const INITIAL_BALANCE_MICRO_ALGOS = Number(20e6)
 
-export const getAlgorandAppClientV11 = async (appSpec: AppSpec) => {
-  if ((await getAlgodMajorVersion()) < 4) {
-    return undefined
-  }
-  const [appClient, _] = await getAlgorandAppClientWithApp(appSpec)
-  return appClient
-}
-
 export const getAlgorandAppClient = async (appSpec: AppSpec) => {
   const [appClient, _] = await getAlgorandAppClientWithApp(appSpec)
   return appClient

--- a/tests/crypto-op-codes.spec.ts
+++ b/tests/crypto-op-codes.spec.ts
@@ -31,7 +31,7 @@ describe('crypto op codes', async () => {
   const [appClient, app] = await getAlgorandAppClientWithApp(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/global-state-arc4-values.spec.ts
+++ b/tests/global-state-arc4-values.spec.ts
@@ -23,7 +23,7 @@ describe('ARC4 AppGlobal values', async () => {
   const defaultSenderAccountAddress = Bytes.fromBase32(localNetAccount.addr.toString())
   const ctx = new TestExecutionContext(defaultSenderAccountAddress)
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/local-state-arc4-values.spec.ts
+++ b/tests/local-state-arc4-values.spec.ts
@@ -25,7 +25,7 @@ describe('ARC4 AppLocal values', async () => {
   const ctx = new TestExecutionContext(defaultSenderAccountAddress)
   await tryOptIn(appClient)
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/log.spec.ts
+++ b/tests/log.spec.ts
@@ -26,7 +26,7 @@ describe('log', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/match.spec.ts
+++ b/tests/match.spec.ts
@@ -6,7 +6,7 @@ import { StrImpl } from '../src/impl/encoded-types'
 describe('match', () => {
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/pure-op-codes.spec.ts
+++ b/tests/pure-op-codes.spec.ts
@@ -23,7 +23,7 @@ describe('Pure op codes', async () => {
   const appClient = await getAlgorandAppClient(appSpecJson as AppSpec)
   const ctx = new TestExecutionContext()
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 

--- a/tests/state-op-codes.spec.ts
+++ b/tests/state-op-codes.spec.ts
@@ -38,9 +38,7 @@ import { StateAcctParamsGetContract } from './artifacts/state-ops/state-acct-par
 import {
   generateTestAccount,
   generateTestAsset,
-  getAlgodMajorVersion,
   getAlgorandAppClient,
-  getAlgorandAppClientV11,
   getAlgorandAppClientWithApp,
   getAvmResult,
   getLocalNetDefaultAccount,
@@ -49,15 +47,13 @@ import {
 
 describe('State op codes', async () => {
   const ctx = new TestExecutionContext()
-  const algodVersion = await getAlgodMajorVersion()
-  const isV11Supported = algodVersion > 4
 
   afterEach(() => {
     ctx.reset()
   })
 
-  describe.skipIf(!isV11Supported)('AcctParams', async () => {
-    const [appClient, dummyAccount] = await Promise.all([getAlgorandAppClientV11(acctParamsAppSpecJson as AppSpec), generateTestAccount()])
+  describe('AcctParams', async () => {
+    const [appClient, dummyAccount] = await Promise.all([getAlgorandAppClient(acctParamsAppSpecJson as AppSpec), generateTestAccount()])
 
     test.each([
       ['verify_acct_balance', INITIAL_BALANCE_MICRO_ALGOS + 100_000],
@@ -90,7 +86,7 @@ describe('State op codes', async () => {
       })
 
       const avmResult = await getAvmResult(
-        { appClient: appClient!, sendParams: { staticFee: AlgoAmount.Algos(1000) } },
+        { appClient, sendParams: { staticFee: AlgoAmount.Algos(1000) } },
         methodName,
         asUint8Array(dummyAccount.bytes),
       )
@@ -113,7 +109,7 @@ describe('State op codes', async () => {
         expect(op.AcctParams.acctIncentiveEligible(mockAccount)).toEqual([true, true])
       })
 
-      await appClient!.algorand.send.onlineKeyRegistration({
+      await appClient.algorand.send.onlineKeyRegistration({
         sender: encodeAddress(asUint8Array(dummyAccount.bytes)),
         voteKey: getRandomBytes(32).asUint8Array(),
         selectionKey: getRandomBytes(32).asUint8Array(),
@@ -124,7 +120,7 @@ describe('State op codes', async () => {
         staticFee: AlgoAmount.Algos(10),
       })
       const avmResult = await getAvmResult(
-        { appClient: appClient!, sendParams: { staticFee: AlgoAmount.Algos(10) } },
+        { appClient, sendParams: { staticFee: AlgoAmount.Algos(10) } },
         'verify_acct_incentive_eligible',
         asUint8Array(dummyAccount.bytes),
       )

--- a/tests/state-op-codes.spec.ts
+++ b/tests/state-op-codes.spec.ts
@@ -52,7 +52,7 @@ describe('State op codes', async () => {
   const algodVersion = await getAlgodMajorVersion()
   const isV11Supported = algodVersion > 4
 
-  afterEach(async () => {
+  afterEach(() => {
     ctx.reset()
   })
 


### PR DESCRIPTION
*also*:
- remove unnecessary `async` keyword from test functions