### PR TITLE
feat: add npm script to refresh test artifacts by recompiling contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run --coverage --reporter junit --outputFile test-results.xml",
-    "build-examples": "rollup --config examples/rollup.config.ts --configPlugin typescript"
+    "build-examples": "rollup --config examples/rollup.config.ts --configPlugin typescript",
+    "script:refresh-test-artifacts": "puya-ts build --out-dir data ./tests/artifacts/*/"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-utils": "^8.1.0",

--- a/tests/artifacts/arc4-primitive-ops/data/Arc4PrimitiveOpsContract.arc56.json
+++ b/tests/artifacts/arc4-primitive-ops/data/Arc4PrimitiveOpsContract.arc56.json
@@ -1716,7 +1716,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [

--- a/tests/artifacts/box-contract/data/BoxContract.arc56.json
+++ b/tests/artifacts/box-contract/data/BoxContract.arc56.json
@@ -132,7 +132,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/created-app-asset/data/AppExpectingEffects.arc56.json
+++ b/tests/artifacts/created-app-asset/data/AppExpectingEffects.arc56.json
@@ -181,7 +181,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/crypto-ops/data/CryptoOpsContract.arc56.json
+++ b/tests/artifacts/crypto-ops/data/CryptoOpsContract.arc56.json
@@ -494,7 +494,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/miscellaneous-ops/data/MiscellaneousOpsContract.arc56.json
+++ b/tests/artifacts/miscellaneous-ops/data/MiscellaneousOpsContract.arc56.json
@@ -1028,7 +1028,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/multi-inheritance/data/BaseOne.arc56.json
+++ b/tests/artifacts/multi-inheritance/data/BaseOne.arc56.json
@@ -141,7 +141,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/multi-inheritance/data/BaseTwo.arc56.json
+++ b/tests/artifacts/multi-inheritance/data/BaseTwo.arc56.json
@@ -142,7 +142,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/multi-inheritance/data/CommonBase.arc56.json
+++ b/tests/artifacts/multi-inheritance/data/CommonBase.arc56.json
@@ -118,7 +118,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/multi-inheritance/data/MultiBases.arc56.json
+++ b/tests/artifacts/multi-inheritance/data/MultiBases.arc56.json
@@ -241,7 +241,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/primitive-ops/data/PrimitiveOpsContract.arc56.json
+++ b/tests/artifacts/primitive-ops/data/PrimitiveOpsContract.arc56.json
@@ -1628,7 +1628,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/GlobalStateContract.arc56.json
+++ b/tests/artifacts/state-ops/data/GlobalStateContract.arc56.json
@@ -740,7 +740,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/ITxnOpsContract.arc56.json
+++ b/tests/artifacts/state-ops/data/ITxnOpsContract.arc56.json
@@ -94,7 +94,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/LocalStateContract.arc56.json
+++ b/tests/artifacts/state-ops/data/LocalStateContract.arc56.json
@@ -511,7 +511,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAcctParamsGetContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAcctParamsGetContract.arc56.json
@@ -454,7 +454,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAppGlobalContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAppGlobalContract.arc56.json
@@ -264,7 +264,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAppGlobalExContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAppGlobalExContract.arc56.json
@@ -96,7 +96,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAppLocalContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAppLocalContract.arc56.json
@@ -342,7 +342,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAppLocalExContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAppLocalExContract.arc56.json
@@ -110,7 +110,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAppParamsContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAppParamsContract.arc56.json
@@ -311,7 +311,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAssetHoldingContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAssetHoldingContract.arc56.json
@@ -130,7 +130,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],

--- a/tests/artifacts/state-ops/data/StateAssetParamsContract.arc56.json
+++ b/tests/artifacts/state-ops/data/StateAssetParamsContract.arc56.json
@@ -386,7 +386,7 @@
         "compilerVersion": {
             "major": 4,
             "minor": 2,
-            "patch": 0
+            "patch": 1
         }
     },
     "events": [],


### PR DESCRIPTION
- add npm script to refresh test artifacts by recompiling contracts using current version of puya-ts
   ```sh
   npm run script:refresh-test-artifacts
   ```