### PR TITLE
fix: add step to install puyapy in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
     with:
       pre-test-script: |
         pipx install algokit
-        algokit localnet start
+        algokit localnet reset --update
+        pipx install puyapy
       node-version: 20.x
       run-build: true
       run-commit-lint: true


### PR DESCRIPTION
*fix:*
- add step to install `puyapy` in the release pipeline as the contracts used by tests are now compiled as part of test run