### PR TITLE
feat: implement stubs for Box create, no arg ctors, and encode/decode native arrays

### DIFF
--- a/examples/auction/contract.algo.ts
+++ b/examples/auction/contract.algo.ts
@@ -26,7 +26,6 @@ export class Auction extends Contract {
 
   claimableAmount = LocalState<uint64>()
 
-  @abimethod({ allowActions: 'NoOp', onCreate: 'require' })
   public createApplication(): void {
     this.auctionEnd.value = 0
     this.previousBid.value = 0
@@ -82,7 +81,7 @@ export class Auction extends Contract {
   }
 
   @abimethod({ allowActions: 'OptIn' })
-  public optInToApplication(): void {}
+  public optInToApplication(): void { }
 
   public bid(payment: gtxn.PaymentTxn): void {
     /// Ensure auction hasn't ended

--- a/examples/auction/contract.algo.ts
+++ b/examples/auction/contract.algo.ts
@@ -81,7 +81,7 @@ export class Auction extends Contract {
   }
 
   @abimethod({ allowActions: 'OptIn' })
-  public optInToApplication(): void { }
+  public optInToApplication(): void {}
 
   public bid(payment: gtxn.PaymentTxn): void {
     /// Ensure auction hasn't ended

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@algorandfoundation/algorand-typescript-testing",
       "version": "1.0.0",
       "dependencies": {
-        "@algorandfoundation/algorand-typescript": "1.0.0-beta.65",
-        "@algorandfoundation/puya-ts": "1.0.0-beta.65",
+        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
+        "@algorandfoundation/puya-ts": "1.0.0-alpha.47",
         "elliptic": "^6.6.1",
         "js-sha256": "^0.11.0",
         "js-sha3": "^0.9.3",
@@ -73,21 +73,21 @@
       }
     },
     "node_modules/@algorandfoundation/algorand-typescript": {
-      "version": "1.0.0-beta.65",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript/-/algorand-typescript-1.0.0-beta.65.tgz",
-      "integrity": "sha512-XbMXOsMXw/p+5VaD9LiYrCVRgahHG9ZpEXwAj6hqwMtnyIpwxes1gVtCljg/NtQ4Zj3TlWsU2dtxLBSAqF8iKQ==",
+      "version": "1.0.0-alpha.47",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript/-/algorand-typescript-1.0.0-alpha.47.tgz",
+      "integrity": "sha512-7DKwvm5IdJy//OCo2eK+kwIY59OyNU/Nxlu9KT61PA+pirY5t9eZqeLczQobA63NCBDgh+BXJKrzO0pEYIEAvg==",
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@algorandfoundation/puya-ts": {
-      "version": "1.0.0-beta.65",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/puya-ts/-/puya-ts-1.0.0-beta.65.tgz",
-      "integrity": "sha512-+jM1el9mL0jOnGTDD4q3lMMHdFY7VZ0xg6UqGfoz/Macr+uZ5JvlgzgZUemCeH6zEzPcoLlOTosL9BeEiE1e7Q==",
+      "version": "1.0.0-alpha.47",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/puya-ts/-/puya-ts-1.0.0-alpha.47.tgz",
+      "integrity": "sha512-yBLzGb7jdt3Bma7ErT88YbWKGw8dqMC1xMh5rY8bIXvGthf+uwZsjvOQ/IxIRnYVljZ2ZBuolmvPVAhgF+4gZg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@algorandfoundation/algorand-typescript": "1.0.0-beta.65",
+        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
         "arcsecond": "^5.0.0",
         "argparse": "^2.0.1",
         "chalk": "^5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@algorandfoundation/algorand-typescript-testing",
       "version": "1.0.0",
       "dependencies": {
-        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
-        "@algorandfoundation/puya-ts": "1.0.0-alpha.47",
+        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.49",
+        "@algorandfoundation/puya-ts": "1.0.0-alpha.49",
         "elliptic": "^6.6.1",
         "js-sha256": "^0.11.0",
         "js-sha3": "^0.9.3",
@@ -73,21 +73,21 @@
       }
     },
     "node_modules/@algorandfoundation/algorand-typescript": {
-      "version": "1.0.0-alpha.47",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript/-/algorand-typescript-1.0.0-alpha.47.tgz",
-      "integrity": "sha512-7DKwvm5IdJy//OCo2eK+kwIY59OyNU/Nxlu9KT61PA+pirY5t9eZqeLczQobA63NCBDgh+BXJKrzO0pEYIEAvg==",
+      "version": "1.0.0-alpha.49",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript/-/algorand-typescript-1.0.0-alpha.49.tgz",
+      "integrity": "sha512-fZhuOGl9iAzeea7VvK0VCvi0aXy1yDjgIYKvNgG+4wwFNeUTVBDZGjwWspDYhlO5Jk+iaJX1kVLgwwh+/XG4+A==",
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@algorandfoundation/puya-ts": {
-      "version": "1.0.0-alpha.47",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/puya-ts/-/puya-ts-1.0.0-alpha.47.tgz",
-      "integrity": "sha512-yBLzGb7jdt3Bma7ErT88YbWKGw8dqMC1xMh5rY8bIXvGthf+uwZsjvOQ/IxIRnYVljZ2ZBuolmvPVAhgF+4gZg==",
+      "version": "1.0.0-alpha.49",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/puya-ts/-/puya-ts-1.0.0-alpha.49.tgz",
+      "integrity": "sha512-WV4nBLgJ1u/vMQja1c1K0UYFwmZlmzGDovBzR4AJkyq8+/GSwKviIC1c1/FbR6w4ibE/dlzDuZcc2AouY00gjg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
+        "@algorandfoundation/algorand-typescript": "1.0.0-alpha.49",
         "arcsecond": "^5.0.0",
         "argparse": "^2.0.1",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "vitest": "3.0.9"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
-    "@algorandfoundation/puya-ts": "1.0.0-alpha.47",
+    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.49",
+    "@algorandfoundation/puya-ts": "1.0.0-alpha.49",
     "elliptic": "^6.6.1",
     "js-sha256": "^0.11.0",
     "js-sha3": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "vitest": "3.0.9"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "1.0.0-beta.65",
-    "@algorandfoundation/puya-ts": "1.0.0-beta.65",
+    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.47",
+    "@algorandfoundation/puya-ts": "1.0.0-alpha.47",
     "elliptic": "^6.6.1",
     "js-sha256": "^0.11.0",
     "js-sha3": "^0.9.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,3 +66,13 @@ export enum OnApplicationComplete {
   UpdateApplicationOC = 4,
   DeleteApplicationOC = 5,
 }
+
+export const ConventionalRouting = {
+  methodNames: {
+    closeOutOfApplication: 'closeOutOfApplication',
+    createApplication: 'createApplication',
+    deleteApplication: 'deleteApplication',
+    optInToApplication: 'optInToApplication',
+    updateApplication: 'updateApplication',
+  },
+}

--- a/src/encoders.ts
+++ b/src/encoders.ts
@@ -63,7 +63,7 @@ export const getEncoder = <T>(typeInfo: TypeInfo): fromBytes<T> => {
 }
 
 export const toBytes = (val: unknown): bytes => {
-  const uint64Val = asMaybeUint64Cls(val)
+  const uint64Val = asMaybeUint64Cls(val, false)
   if (uint64Val !== undefined) {
     return uint64Val.toBytes().asAlgoTs()
   }

--- a/src/encoders.ts
+++ b/src/encoders.ts
@@ -85,7 +85,7 @@ export const toBytes = (val: unknown): bytes => {
     return val.bytes
   }
   if (Array.isArray(val) || typeof val === 'object') {
-    return encodeArc4Impl('', val)
+    return encodeArc4Impl(undefined, val)
   }
   throw new InternalError(`Invalid type for bytes: ${nameOfType(val)}`)
 }

--- a/src/encoders.ts
+++ b/src/encoders.ts
@@ -3,7 +3,7 @@ import { ARC4Encoded } from '@algorandfoundation/algorand-typescript/arc4'
 import { encodingUtil } from '@algorandfoundation/puya-ts'
 import { InternalError } from './errors'
 import { BytesBackedCls, Uint64BackedCls } from './impl/base'
-import { arc4Encoders, encodeArc4Impl, getArc4Encoder } from './impl/encoded-types'
+import { arc4Encoders, encodeArc4Impl, getArc4Encoder, tryArc4EncodedLengthImpl } from './impl/encoded-types'
 import { BigUint, Uint64, type StubBytesCompat } from './impl/primitives'
 import { AccountCls, ApplicationCls, AssetCls } from './impl/reference'
 import type { DeliberateAny } from './typescript-helpers'
@@ -88,4 +88,9 @@ export const toBytes = (val: unknown): bytes => {
     return encodeArc4Impl('', val)
   }
   throw new InternalError(`Invalid type for bytes: ${nameOfType(val)}`)
+}
+
+export const minLengthForType = (typeInfo: TypeInfo): number => {
+  const minArc4StaticLength = tryArc4EncodedLengthImpl(typeInfo)
+  return minArc4StaticLength ?? 0
 }

--- a/src/impl/c2c.ts
+++ b/src/impl/c2c.ts
@@ -89,8 +89,15 @@ export function abiCall<TArgs extends DeliberateAny[], TReturn>(
   methodArgs: TypedApplicationCallFields<TArgs>,
   contract?: Contract | { new (): Contract },
 ): { itxn: ApplicationCallInnerTxn; returnValue: TReturn | undefined } {
+  const abiMetadata = contract ? getContractMethodAbiMetadata(contract, method.name) : undefined
   const selector = methodSelector(method, contract)
-  const itxnContext = ApplicationCallInnerTxnContext.createFromTypedApplicationCallFields<TReturn>(methodArgs, selector)
+  const itxnContext = ApplicationCallInnerTxnContext.createFromTypedApplicationCallFields<TReturn>(
+    {
+      ...methodArgs,
+      onCompletion: methodArgs.onCompletion ?? abiMetadata?.allowActions?.map((action) => OnCompleteAction[action])[0],
+    },
+    selector,
+  )
   invokeCallback(itxnContext)
 
   return {

--- a/src/impl/encoded-types.ts
+++ b/src/impl/encoded-types.ts
@@ -2,6 +2,7 @@ import type {
   Account as AccountType,
   BigUintCompat,
   bytes,
+  NTuple,
   StringCompat,
   uint64,
   Uint64Compat,
@@ -127,14 +128,14 @@ export class UFixedNxMImpl<N extends BitSize, M extends number> extends UFixedNx
   private precision: M
   typeInfo: TypeInfo
 
-  constructor(typeInfo: TypeInfo | string, v: `${number}.${number}`) {
+  constructor(typeInfo: TypeInfo | string, v?: `${number}.${number}`) {
     super(v)
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     const genericArgs = this.typeInfo.genericArgs as uFixedNxMGenericArgs
     this.bitSize = UFixedNxMImpl.getMaxBitsLength(this.typeInfo) as N
     this.precision = parseInt(genericArgs.m.name, 10) as M
 
-    const trimmedValue = trimTrailingDecimalZeros(v)
+    const trimmedValue = trimTrailingDecimalZeros(v ?? '0.0')
     assert(regExpNxM(this.precision).test(trimmedValue), `expected positive decimal literal with max of ${this.precision} decimal places`)
 
     const bigIntValue = BigInt(trimmedValue.replace('.', ''))
@@ -308,7 +309,7 @@ const checkItemTypeName = (type: TypeInfo, value: ARC4Encoded) => {
 }
 type StaticArrayGenericArgs = { elementType: TypeInfo; size: TypeInfo }
 const arrayProxyHandler = <TItem>() => ({
-  get(target: { items: TItem[] }, prop: PropertyKey) {
+  get(target: { items: readonly TItem[] }, prop: PropertyKey) {
     const idx = prop ? parseInt(prop.toString(), 10) : NaN
     if (!isNaN(idx)) {
       if (idx >= 0 && idx < target.items.length) return target.items[idx]
@@ -337,8 +338,9 @@ const arrayProxyHandler = <TItem>() => ({
     return Reflect.set(target, prop, value)
   },
 })
+const isInitialisingFromBytesSymbol = Symbol('IsInitialisingFromBytes')
 export class StaticArrayImpl<TItem extends ARC4Encoded, TLength extends number> extends StaticArray<TItem, TLength> {
-  private value?: TItem[]
+  private value?: NTuple<TItem, TLength>
   private uint8ArrayValue?: Uint8Array
   private size: number
   typeInfo: TypeInfo
@@ -347,23 +349,33 @@ export class StaticArrayImpl<TItem extends ARC4Encoded, TLength extends number> 
   constructor(typeInfo: TypeInfo | string, ...items: TItem[] & { length: TLength })
   constructor(typeInfo: TypeInfo | string, ...items: TItem[])
   constructor(typeInfo: TypeInfo | string, ...items: TItem[] & { length: TLength }) {
-    super(...(items as DeliberateAny))
+    // if first item is the symbol, we are initialising from bytes
+    // so we don't need to pass the items to the super constructor
+    const isInitialisingFromBytes = items.length === 1 && (items[0] as DeliberateAny) === isInitialisingFromBytesSymbol
+    super(...(isInitialisingFromBytes ? [] : (items as DeliberateAny)))
+
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this.genericArgs = this.typeInfo.genericArgs as StaticArrayGenericArgs
-
     this.size = parseInt(this.genericArgs.size.name, 10)
-    if (items.length && items.length !== this.size) {
-      throw new CodeError(`expected ${this.size} items, not ${items.length}`)
+
+    // if we are not initialising from bytes, we need to check and set the items
+    if (!isInitialisingFromBytes) {
+      if (items.length && items.length !== this.size) {
+        throw new CodeError(`expected ${this.size} items, not ${items.length}`)
+      }
+
+      assert(areAllARC4Encoded(items), 'expected ARC4 type')
+
+      items.forEach((item) => {
+        checkItemTypeName(this.genericArgs.elementType, item)
+      })
+
+      if (items.length) {
+        this.value = items as NTuple<TItem, TLength>
+      } else {
+        this.uint8ArrayValue = new Uint8Array(StaticArrayImpl.getMaxBytesLength(this.typeInfo))
+      }
     }
-
-    assert(areAllARC4Encoded(items), 'expected ARC4 type')
-
-    items.forEach((item) => {
-      checkItemTypeName(this.genericArgs.elementType, item)
-    })
-
-    this.value = items.length ? items : undefined
-
     return new Proxy(this, arrayProxyHandler<TItem>()) as StaticArrayImpl<TItem, TLength>
   }
 
@@ -382,10 +394,10 @@ export class StaticArrayImpl<TItem extends ARC4Encoded, TLength extends number> 
     return this.size
   }
 
-  get items(): TItem[] {
+  get items(): NTuple<TItem, TLength> {
     if (this.uint8ArrayValue) {
       const childTypes = Array(this.size).fill(this.genericArgs.elementType)
-      this.value = decode(this.uint8ArrayValue, childTypes) as TItem[]
+      this.value = decode(this.uint8ArrayValue, childTypes) as NTuple<TItem, TLength>
       this.uint8ArrayValue = undefined
       return this.value
     } else if (this.value) {
@@ -417,7 +429,7 @@ export class StaticArrayImpl<TItem extends ARC4Encoded, TLength extends number> 
     )
   }
 
-  get native(): TItem[] {
+  get native(): NTuple<TItem, TLength> {
     return this.items
   }
 
@@ -431,7 +443,8 @@ export class StaticArrayImpl<TItem extends ARC4Encoded, TLength extends number> 
       assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
       bytesValue = bytesValue.slice(4)
     }
-    const result = new StaticArrayImpl(typeInfo)
+    // pass the symbol to the constructor to let it know we are initialising from bytes
+    const result = new StaticArrayImpl<ARC4Encoded, number>(typeInfo, isInitialisingFromBytesSymbol as DeliberateAny)
     result.uint8ArrayValue = asUint8Array(bytesValue)
     return result
   }
@@ -504,7 +517,7 @@ export class AddressImpl extends Address {
     return Account(this.value.bytes)
   }
 
-  get items(): ByteImpl[] {
+  get items(): readonly ByteImpl[] {
     return this.value.items
   }
 
@@ -646,18 +659,27 @@ export class TupleImpl<TTuple extends [ARC4Encoded, ...ARC4Encoded[]]> extends T
   typeInfo: TypeInfo
   genericArgs: TypeInfo[]
 
-  constructor(typeInfo: TypeInfo | string)
   constructor(typeInfo: TypeInfo | string, ...items: TTuple) {
-    super(...items)
+    // if first item is the symbol, we are initialising from bytes
+    // so we don't need to pass the items to the super constructor
+    const isInitialisingFromBytes = items.length === 1 && (items[0] as DeliberateAny) === isInitialisingFromBytesSymbol
+    super(...(isInitialisingFromBytes ? ([] as DeliberateAny) : items))
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this.genericArgs = Object.values(this.typeInfo.genericArgs as Record<string, TypeInfo>)
 
-    assert(areAllARC4Encoded(items), 'expected ARC4 type')
+    // if we are not initialising from bytes, we need to check and set the items
+    if (!isInitialisingFromBytes) {
+      assert(areAllARC4Encoded(items), 'expected ARC4 type')
 
-    items.forEach((item, index) => {
-      checkItemTypeName(this.genericArgs[index], item)
-    })
-    this.value = items.length ? items : undefined
+      items.forEach((item, index) => {
+        checkItemTypeName(this.genericArgs[index], item)
+      })
+      if (items.length) {
+        this.value = items
+      } else {
+        this.uint8ArrayValue = new Uint8Array(TupleImpl.getMaxBytesLength(this.typeInfo))
+      }
+    }
   }
 
   get bytes(): bytes {
@@ -705,7 +727,8 @@ export class TupleImpl<TTuple extends [ARC4Encoded, ...ARC4Encoded[]]> extends T
       assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
       bytesValue = bytesValue.slice(4)
     }
-    const result = new TupleImpl(typeInfo)
+    // pass the symbol to the constructor to let it know we are initialising from bytes
+    const result = new TupleImpl(typeInfo, isInitialisingFromBytesSymbol as DeliberateAny)
     result.uint8ArrayValue = asUint8Array(bytesValue)
     return result
   }
@@ -920,9 +943,9 @@ export class StaticBytesImpl extends StaticBytes {
 
   constructor(typeInfo: TypeInfo | string, value?: bytes | string) {
     super(value)
-    const uint8ArrayValue = asUint8Array(value ?? new Uint8Array())
-    this.value = StaticArrayImpl.fromBytesImpl(uint8ArrayValue, typeInfo) as StaticArrayImpl<ByteImpl, number>
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    const uint8ArrayValue = asUint8Array(value ?? new Uint8Array(StaticBytesImpl.getMaxBytesLength(this.typeInfo)))
+    this.value = StaticArrayImpl.fromBytesImpl(uint8ArrayValue, typeInfo) as StaticArrayImpl<ByteImpl, number>
     return new Proxy(this, arrayProxyHandler<ByteImpl>()) as StaticBytesImpl
   }
 
@@ -1086,6 +1109,8 @@ const getMaxLengthOfStaticContentType = (type: TypeInfo): number => {
     case 'biguint':
       return UINT512_SIZE / BITS_IN_BYTE
     case 'boolean':
+      return 8
+    case 'Bool':
       return 1
     case 'Address':
       return AddressImpl.getMaxBytesLength(type)
@@ -1103,8 +1128,9 @@ const getMaxLengthOfStaticContentType = (type: TypeInfo): number => {
       return TupleImpl.getMaxBytesLength(type)
     case 'Struct':
       return StructImpl.getMaxBytesLength(type)
+    default:
+      throw new CodeError(`unsupported type ${type.name}`)
   }
-  throw new CodeError(`unsupported type ${type.name}`)
 }
 
 const encode = (values: ARC4Encoded[]) => {
@@ -1338,7 +1364,7 @@ export const getArc4Encoded = (value: DeliberateAny): ARC4Encoded => {
     }, [])
     const genericArgs: TypeInfo[] = result.map((x) => (x as DeliberateAny).typeInfo)
     const typeInfo = { name: `Tuple<[${genericArgs.map((x) => x.name).join(',')}]>`, genericArgs }
-    return new TupleImpl(typeInfo, ...(result as []))
+    return new TupleImpl(typeInfo, ...(result as [ARC4Encoded, ...ARC4Encoded[]]))
   }
   if (typeof value === 'object') {
     const result = Object.values(value).reduce((acc: ARC4Encoded[], cur: DeliberateAny) => {
@@ -1358,4 +1384,16 @@ export const getArc4Encoded = (value: DeliberateAny): ARC4Encoded => {
 export const arc4EncodedLengthImpl = (typeInfoString: string): uint64 => {
   const typeInfo = JSON.parse(typeInfoString)
   return getMaxLengthOfStaticContentType(typeInfo)
+}
+
+export const tryArc4EncodedLengthImpl = (typeInfoString: string | TypeInfo): uint64 | undefined => {
+  const typeInfo = typeof typeInfoString === 'string' ? JSON.parse(typeInfoString) : typeInfoString
+  try {
+    return getMaxLengthOfStaticContentType(typeInfo)
+  } catch (e) {
+    if (e instanceof CodeError && e.message.startsWith('unsupported type')) {
+      return undefined
+    }
+    throw e
+  }
 }

--- a/src/impl/primitives.ts
+++ b/src/impl/primitives.ts
@@ -564,9 +564,9 @@ export class BytesCls extends AlgoTsPrimitiveCls {
 
 export const arrayUtil = new (class ArrayUtil {
   arrayAt(arrayLike: Uint8Array, index: StubUint64Compat): Uint8Array
-  arrayAt<T>(arrayLike: T[], index: StubUint64Compat): T
-  arrayAt<T>(arrayLike: T[] | Uint8Array, index: StubUint64Compat): T | Uint8Array
-  arrayAt<T>(arrayLike: T[] | Uint8Array, index: StubUint64Compat): T | Uint8Array {
+  arrayAt<T>(arrayLike: readonly T[], index: StubUint64Compat): T
+  arrayAt<T>(arrayLike: readonly T[] | Uint8Array, index: StubUint64Compat): T | Uint8Array
+  arrayAt<T>(arrayLike: readonly T[] | Uint8Array, index: StubUint64Compat): T | Uint8Array {
     const indexNum = getNumber(index)
     if (arrayLike instanceof Uint8Array) {
       const res = arrayLike.slice(indexNum, indexNum === -1 ? undefined : indexNum + 1)
@@ -576,9 +576,13 @@ export const arrayUtil = new (class ArrayUtil {
     return arrayLike.at(indexNum) ?? avmError('Index out of bounds')
   }
   arraySlice(arrayLike: Uint8Array, start: undefined | StubUint64Compat, end: undefined | StubUint64Compat): Uint8Array
-  arraySlice<T>(arrayLike: T[], start: undefined | StubUint64Compat, end: undefined | StubUint64Compat): T[]
-  arraySlice<T>(arrayLike: T[] | Uint8Array, start: undefined | StubUint64Compat, end: undefined | StubUint64Compat): Uint8Array | T[]
-  arraySlice<T>(arrayLike: T[] | Uint8Array, start: undefined | StubUint64Compat, end: undefined | StubUint64Compat) {
+  arraySlice<T>(arrayLike: readonly T[], start: undefined | StubUint64Compat, end: undefined | StubUint64Compat): T[]
+  arraySlice<T>(
+    arrayLike: readonly T[] | Uint8Array,
+    start: undefined | StubUint64Compat,
+    end: undefined | StubUint64Compat,
+  ): Uint8Array | T[]
+  arraySlice<T>(arrayLike: readonly T[] | Uint8Array, start: undefined | StubUint64Compat, end: undefined | StubUint64Compat) {
     const startNum = start === undefined ? undefined : getNumber(start)
     const endNum = end === undefined ? undefined : getNumber(end)
     if (arrayLike instanceof Uint8Array) {

--- a/src/impl/state.ts
+++ b/src/impl/state.ts
@@ -15,9 +15,9 @@ import { AccountMap } from '../collections/custom-key-map'
 import { MAX_BOX_SIZE } from '../constants'
 import { lazyContext } from '../context-helpers/internal-context'
 import type { TypeInfo } from '../encoders'
-import { getEncoder, toBytes } from '../encoders'
-import { AssertError, InternalError } from '../errors'
-import { getGenericTypeInfo } from '../runtime-helpers'
+import { getEncoder, minLengthForType, toBytes } from '../encoders'
+import { AssertError, CodeError, InternalError } from '../errors'
+import { getGenericTypeInfo, tryArc4EncodedLengthImpl } from '../runtime-helpers'
 import { asBytes, asBytesCls, asNumber, asUint8Array, conactUint8Arrays } from '../util'
 import type { StubBytesCompat, StubUint64Compat } from './primitives'
 import { Bytes, Uint64, Uint64Cls } from './primitives'
@@ -135,6 +135,16 @@ export class BoxCls<TValue> {
   #valueType?: TypeInfo
 
   private readonly _type: string = BoxCls.name
+  private get valueType(): TypeInfo {
+    if (this.#valueType === undefined) {
+      const typeInfo = getGenericTypeInfo(this)
+      if (typeInfo === undefined || typeInfo.genericArgs === undefined || typeInfo.genericArgs.length !== 1) {
+        throw new InternalError('Box value type is not set')
+      }
+      this.#valueType = (typeInfo.genericArgs as TypeInfo[])[0]
+    }
+    return this.#valueType
+  }
 
   static [Symbol.hasInstance](x: unknown): x is BoxCls<unknown> {
     return x instanceof Object && '_type' in x && (x as { _type: string })['_type'] === BoxCls.name
@@ -147,8 +157,31 @@ export class BoxCls<TValue> {
   }
 
   private get fromBytes() {
-    const valueType = this.#valueType ?? (getGenericTypeInfo(this)!.genericArgs! as TypeInfo[])[0]
-    return (val: Uint8Array) => getEncoder<TValue>(valueType)(val, valueType)
+    return (val: Uint8Array) => getEncoder<TValue>(this.valueType)(val, this.valueType)
+  }
+
+  create(options?: { size?: StubUint64Compat }): boolean {
+    const optionSize = options?.size !== undefined ? asNumber(options.size) : undefined
+    const valueTypeSize = tryArc4EncodedLengthImpl(this.valueType)
+    if (valueTypeSize === undefined && optionSize === undefined) {
+      throw new InternalError(`${this.valueType.name} does not have a fixed byte size. Please specify a size argument`)
+    }
+    if (valueTypeSize !== undefined && optionSize !== undefined) {
+      if (optionSize < valueTypeSize) {
+        throw new InternalError(`Box size cannot be less than ${valueTypeSize}`)
+      }
+      if (optionSize > valueTypeSize) {
+        process.emitWarning(
+          `Box size is set to ${optionSize} but the value type ${this.valueType.name} has a fixed size of ${valueTypeSize}`,
+        )
+      }
+    }
+    lazyContext.ledger.setBox(
+      this.#app,
+      this.key,
+      new Uint8Array(Math.max(asNumber(options?.size ?? 0), this.valueType ? minLengthForType(this.valueType) : 0)),
+    )
+    return true
   }
 
   get value(): TValue {
@@ -165,7 +198,15 @@ export class BoxCls<TValue> {
     return materialised
   }
   set value(v: TValue) {
-    lazyContext.ledger.setBox(this.#app, this.key, asUint8Array(toBytes(v)))
+    const isStaticValueType = tryArc4EncodedLengthImpl(this.valueType) !== undefined
+    const newValueBytes = asUint8Array(toBytes(v))
+    if (isStaticValueType && this.exists) {
+      const originalValueBytes = lazyContext.ledger.getBox(this.#app, this.key)
+      if (originalValueBytes.length !== newValueBytes.length) {
+        throw new CodeError(`attempt to box_put wrong size ${originalValueBytes.length} != ${newValueBytes.length}`)
+      }
+    }
+    lazyContext.ledger.setBox(this.#app, this.key, newValueBytes)
     lazyContext.ledger.setMatrialisedBox(this.#app, this.key, v)
   }
 
@@ -192,7 +233,7 @@ export class BoxCls<TValue> {
     if (!this.exists) {
       throw new InternalError('Box has not been created')
     }
-    return toBytes(this.value).length
+    return lazyContext.ledger.getBox(this.#app, this.key).length
   }
 
   get(options: { default: TValue }): TValue {

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -279,6 +279,9 @@ const getContractOptions = (contract: BaseContract): ContractOptionsParameter | 
 }
 
 const hasCreateMethods = (contract: Contract) => {
+  const createFn = Reflect.get(contract, 'createApplication')
+  if (createFn !== undefined && typeof createFn === 'function') return true
+
   const metadatas = getContractAbiMetadata(contract)
   return Object.values(metadatas).some((metadata) => (metadata.onCreate ?? 'disallow') !== 'disallow')
 }

--- a/src/test-transformer/node-factory.ts
+++ b/src/test-transformer/node-factory.ts
@@ -94,8 +94,10 @@ export const nodeFactory = {
     )
   },
 
-  callStubbedFunction(functionName: string, node: ts.CallExpression, typeInfo?: TypeInfo) {
-    const typeInfoArg = typeInfo ? factory.createStringLiteral(JSON.stringify(typeInfo)) : undefined
+  callStubbedFunction(functionName: string, node: ts.CallExpression, typeInfo?: TypeInfo | TypeInfo[]) {
+    const typeInfoArgs = typeInfo
+      ? (Array.isArray(typeInfo) ? typeInfo : [typeInfo]).map((t) => factory.createStringLiteral(JSON.stringify(t)))
+      : undefined
     const updatedPropertyAccessExpression = factory.createPropertyAccessExpression(
       factory.createIdentifier('runtimeHelpers'),
       `${functionName}Impl`,
@@ -104,7 +106,7 @@ export const nodeFactory = {
     return factory.createCallExpression(
       updatedPropertyAccessExpression,
       node.typeArguments,
-      [typeInfoArg, ...(node.arguments ?? [])].filter((arg) => !!arg),
+      [...(typeInfoArgs ?? []), ...(node.arguments ?? [])].filter((arg) => !!arg),
     )
   },
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,12 +42,14 @@ export const asBytes = (val: StubBytesCompat | Uint8Array) => asBytesCls(val).as
 
 export const asUint8Array = (val: StubBytesCompat | Uint8Array) => asBytesCls(val).asUint8Array()
 
-export const asMaybeUint64Cls = (val: DeliberateAny) => {
+export const asMaybeUint64Cls = (val: DeliberateAny, throwsOverflow: boolean = true) => {
   try {
     return Uint64Cls.fromCompat(val)
   } catch (e) {
     if (e instanceof InternalError) {
       // swallow error and return undefined
+    } else if (!throwsOverflow && e instanceof AvmError && e.message.includes('overflow')) {
+      // swallow overflow error and return undefined
     } else {
       throw e
     }

--- a/tests/arc4/encode-decode-arc4.spec.ts
+++ b/tests/arc4/encode-decode-arc4.spec.ts
@@ -1,17 +1,23 @@
 import type { biguint, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
 import { Bytes } from '@algorandfoundation/algorand-typescript'
-import type { Address, StaticArray, StaticBytes, UFixedNxM, UintN64 } from '@algorandfoundation/algorand-typescript/arc4'
+import type { StaticBytes, UFixedNxM } from '@algorandfoundation/algorand-typescript/arc4'
 import {
+  Address,
   arc4EncodedLength,
   Bool,
   decodeArc4,
+  DynamicArray,
   DynamicBytes,
   encodeArc4,
+  StaticArray,
   Str,
   Struct,
   Tuple,
   UintN,
+  UintN64,
 } from '@algorandfoundation/algorand-typescript/arc4'
+import { itob } from '@algorandfoundation/algorand-typescript/op'
+import { encodingUtil } from '@algorandfoundation/puya-ts'
 import { describe, expect, test } from 'vitest'
 import { MAX_UINT128 } from '../../src/constants'
 import type { StubBytesCompat } from '../../src/impl/primitives'
@@ -30,6 +36,7 @@ const abiUint512 = new UintN<512>(MAX_UINT128)
 const abiBool = new Bool(true)
 const abiBytes = new DynamicBytes(Bytes('hello'))
 
+type TestObj = { a: UintN64; b: DynamicBytes }
 class Swapped1 extends Struct<{
   b: UintN<64>
   c: Bool
@@ -40,13 +47,16 @@ class Swapped1 extends Struct<{
 const testData = [
   {
     nativeValues() {
-      return [nativeNumber, nativeNumber, nativeBigInt, nativeBytes]
+      return [nativeNumber, nativeNumber, nativeBigInt, nativeBytes] as readonly [uint64, uint64, biguint, bytes]
     },
     abiValues() {
       return [abiUint64, abiUint64, abiUint512, abiBytes] as readonly [UintN<64>, UintN<64>, UintN<512>, DynamicBytes]
     },
     arc4Value() {
       return new Tuple<[UintN<64>, UintN<64>, UintN<512>, DynamicBytes]>(abiUint64, abiUint64, abiUint512, abiBytes)
+    },
+    encode() {
+      return encodeArc4(this.nativeValues())
     },
     decode(value: StubBytesCompat) {
       return decodeArc4<[uint64, uint64, biguint, bytes]>(asBytes(value))
@@ -58,6 +68,19 @@ const testData = [
         [nativeBool, [nativeString, nativeBool]],
         [nativeNumber, nativeNumber],
         [nativeBigInt, nativeBytes, { b: nativeNumber, c: nativeBool, d: nativeString, a: [nativeNumber, nativeBool, nativeBool] }],
+      ] as readonly [
+        [boolean, [string, boolean]],
+        [uint64, uint64],
+        [
+          biguint,
+          bytes,
+          {
+            b: uint64
+            c: boolean
+            d: string
+            a: [uint64, boolean, boolean]
+          },
+        ],
       ]
     },
     abiValues() {
@@ -75,6 +98,9 @@ const testData = [
       return new Tuple<[Tuple<[Bool, Tuple<[Str, Bool]>]>, Tuple<[UintN<64>, UintN<64>]>, Tuple<[UintN<512>, DynamicBytes, Swapped1]>]>(
         ...this.abiValues(),
       )
+    },
+    encode() {
+      return encodeArc4(this.nativeValues())
     },
     decode(value: StubBytesCompat) {
       return decodeArc4<
@@ -105,6 +131,9 @@ const testData = [
     arc4Value() {
       return new Swapped1(this.abiValues())
     },
+    encode() {
+      return encodeArc4(this.nativeValues())
+    },
     decode(value: StubBytesCompat) {
       return decodeArc4<{ b: uint64; c: boolean; d: string; a: [uint64, boolean, boolean] }>(asBytes(value))
     },
@@ -120,16 +149,66 @@ describe('decodeArc4', () => {
 
     compareNativeValues(result, nativeValues)
   })
+  test('should be able to decode arrays', () => {
+    const a = 234234
+    const aBytes = asBytes(encodingUtil.bigIntToUint8Array(234234n, 8))
+    const b = true
+    const bBytes = asBytes(encodingUtil.bigIntToUint8Array(128n, 1))
+    const c = 340943934n
+    const cBytes = asBytes(encodingUtil.bigIntToUint8Array(340943934n, 512 / 8))
+    const d = 'hello world'
+    const dBytes = asBytes(
+      new Uint8Array([
+        ...encodingUtil.bigIntToUint8Array(BigInt('hello world'.length), 2),
+        ...encodingUtil.utf8ToUint8Array('hello world'),
+      ]),
+    )
+    const e = { a: 50n, b: new Uint8Array([1, 2, 3, 4, 5]) }
+    const eBytes = asBytes(new Uint8Array([...encodingUtil.bigIntToUint8Array(50n, 8), 0, 10, 0, 5, 1, 2, 3, 4, 5]))
+    const f = new Address(Bytes.fromHex(`${'00'.repeat(31)}ff`))
+    const fBytes = Bytes.fromHex(`${'00'.repeat(31)}ff`)
+    expect(decodeArc4<uint64>(aBytes)).toEqual(a)
+    expect(decodeArc4<boolean>(bBytes)).toEqual(b)
+    expect(decodeArc4<biguint>(cBytes)).toEqual(c)
+    expect(decodeArc4<string>(dBytes)).toEqual(d)
+    expect(decodeArc4<TestObj>(eBytes)).toEqual(e)
+
+    const lenPrefix = itob(1).slice(6, 8)
+    const offsetHeader = itob(2).slice(6, 8)
+    expect(decodeArc4<uint64[]>(lenPrefix.concat(aBytes))).toEqual([a])
+    expect(decodeArc4<boolean[]>(lenPrefix.concat(bBytes))).toEqual([b])
+    expect(decodeArc4<biguint[]>(lenPrefix.concat(cBytes))).toEqual([c])
+    expect(decodeArc4<string[]>(Bytes`${lenPrefix}${offsetHeader}${dBytes}`)).toEqual([d])
+    expect(decodeArc4<TestObj[]>(Bytes`${lenPrefix}${offsetHeader}${eBytes}`)).toEqual([e])
+    expect(JSON.stringify(decodeArc4<Address[]>(Bytes`${lenPrefix}${fBytes}`))).toEqual(JSON.stringify([f]))
+  })
 })
 
 describe('encodeArc4', () => {
   test.each(testData)('should encode native values', (data) => {
-    const nativeValues = data.nativeValues()
     const arc4Value = data.arc4Value()
 
-    const result = encodeArc4(nativeValues)
+    const result = data.encode()
 
     expect(result).toEqual(arc4Value.bytes)
+  })
+  test('should be able to encode arrays', () => {
+    const address = new Address(Bytes.fromHex(`${'00'.repeat(31)}ff`))
+    expect(encodeArc4(address)).toEqual(address.bytes)
+
+    expect(encodeArc4([nativeNumber])).toEqual(new StaticArray(new UintN64(nativeNumber)).bytes)
+    expect(encodeArc4([nativeBool])).toEqual(new StaticArray(new Bool(nativeBool)).bytes)
+    expect(encodeArc4([nativeBigInt])).toEqual(new StaticArray(new UintN<512>(nativeBigInt)).bytes)
+    expect(encodeArc4([nativeBytes])).toEqual(new StaticArray(new DynamicBytes(nativeBytes)).bytes)
+    expect(encodeArc4([nativeString])).toEqual(new StaticArray(new Str(nativeString)).bytes)
+    expect(encodeArc4([address])).toEqual(new StaticArray(address).bytes)
+
+    expect(encodeArc4<uint64[]>([nativeNumber])).toEqual(new DynamicArray(new UintN64(nativeNumber)).bytes)
+    expect(encodeArc4<boolean[]>([nativeBool])).toEqual(new DynamicArray(new Bool(nativeBool)).bytes)
+    expect(encodeArc4<biguint[]>([nativeBigInt])).toEqual(new DynamicArray(new UintN<512>(nativeBigInt)).bytes)
+    expect(encodeArc4<bytes[]>([nativeBytes])).toEqual(new DynamicArray(new DynamicBytes(nativeBytes)).bytes)
+    expect(encodeArc4<string[]>([nativeString])).toEqual(new DynamicArray(new Str(nativeString)).bytes)
+    expect(encodeArc4<Address[]>([address])).toEqual(new DynamicArray(address).bytes)
   })
 })
 

--- a/tests/arc4/encode-decode-arc4.spec.ts
+++ b/tests/arc4/encode-decode-arc4.spec.ts
@@ -145,7 +145,8 @@ describe('arc4EncodedLength', () => {
   test('should return the correct length', () => {
     expect(arc4EncodedLength<uint64>()).toEqual(8)
     expect(arc4EncodedLength<biguint>()).toEqual(64)
-    expect(arc4EncodedLength<boolean>()).toEqual(1)
+    expect(arc4EncodedLength<Bool>()).toEqual(1)
+    expect(arc4EncodedLength<boolean>()).toEqual(8)
     expect(arc4EncodedLength<UintN<512>>()).toEqual(64)
     expect(arc4EncodedLength<[uint64, uint64, boolean]>()).toEqual(17)
     expect(arc4EncodedLength<[uint64, uint64, boolean, boolean]>()).toEqual(17)

--- a/tests/arc4/zero-constructor.spec.ts
+++ b/tests/arc4/zero-constructor.spec.ts
@@ -1,0 +1,50 @@
+import { op } from '@algorandfoundation/algorand-typescript'
+import {
+  Address,
+  Bool,
+  DynamicArray,
+  DynamicBytes,
+  encodeArc4,
+  StaticArray,
+  StaticBytes,
+  Str,
+  Tuple,
+  UFixedNxM,
+  UintN32,
+  UintN8,
+} from '@algorandfoundation/algorand-typescript/arc4'
+import { describe, expect, it } from 'vitest'
+
+describe('initialising ABI values with constructor args', () => {
+  it('should set correct zero values', () => {
+    expect(new StaticArray<UintN8, 4>().bytes).toEqual(new StaticArray(new UintN8(0), new UintN8(0), new UintN8(0), new UintN8(0)).bytes)
+    expect(new StaticArray<Bool, 4>().bytes).toEqual(
+      new StaticArray(new Bool(false), new Bool(false), new Bool(false), new Bool(false)).bytes,
+    )
+    expect(new StaticArray<Bool, 9>().bytes).toEqual(
+      new StaticArray(
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+        new Bool(false),
+      ).bytes,
+    )
+    expect(new DynamicArray<UintN8>().bytes).toEqual(op.bzero(2))
+    expect(new Tuple<[Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool]>().bytes).toEqual(
+      encodeArc4([false, false, false, false, false, false, false, false, false]),
+    )
+    expect(new DynamicArray<Str>().bytes).toEqual(op.bzero(2))
+    expect(new Str().bytes).toEqual(op.bzero(2))
+    expect(new DynamicBytes().bytes).toEqual(op.bzero(2))
+    expect(new StaticBytes<5>().bytes).toEqual(op.bzero(5))
+    expect(new Address().bytes).toEqual(op.bzero(32))
+    expect(new UFixedNxM<32, 4>().bytes).toEqual(op.bzero(32 / 8))
+    expect(new Bool().bytes).toEqual(op.bzero(1))
+    expect(new UintN32().bytes).toEqual(op.bzero(32 / 8))
+  })
+})

--- a/tests/references/arc4-contract.spec.ts
+++ b/tests/references/arc4-contract.spec.ts
@@ -1,5 +1,5 @@
 import type { Account, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
-import { arc4, assert, BaseContract, Bytes, contract, Contract, Global, Txn, Uint64 } from '@algorandfoundation/algorand-typescript'
+import { assert, BaseContract, Bytes, contract, Contract, Global, Txn, Uint64 } from '@algorandfoundation/algorand-typescript'
 import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
 import { afterEach, describe, expect, it } from 'vitest'
 import { lazyContext } from '../../src/context-helpers/internal-context'
@@ -39,8 +39,7 @@ class ContractARC4Create extends Contract {
     this.#stateTotals = Uint64()
   }
 
-  @arc4.abimethod({ onCreate: 'require' })
-  create(val: uint64): void {
+  createApplication(val: uint64): void {
     this.arg1 = val
     assert(Global.currentApplicationId.globalNumBytes === 4)
     assert(Global.currentApplicationId.globalNumUint === 5)
@@ -82,7 +81,7 @@ describe('arc4 contract creation', () => {
 
     const contract = ctx.contract.create(ContractARC4Create)
     ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: ctx.ledger.getApplicationForContract(contract), sender })]).execute(() => {
-      contract.create(arg1)
+      contract.createApplication(arg1)
       expect(contract.arg1).toEqual(arg1)
       expect(contract.creator).toEqual(sender)
     })
@@ -96,7 +95,7 @@ describe('arc4 contract creation', () => {
     const appData = lazyContext.getApplicationData(contract)
     expect(appData.isCreating).toBe(true)
 
-    contract.create(arg1)
+    contract.createApplication(arg1)
 
     expect(appData.isCreating).toBe(false)
     expect(contract.arg1).toEqual(arg1)


### PR DESCRIPTION
*also:*
- set default `allowedActions` and `onCreate` properties of ABI metadata for conventional methods such as `createApplication`, `optInToApplication`, etc.
- set default `onCompletion` property for calls to conventional methods via `abiCall` and `compileArc4(...).call`
