### PR TITLE
ci: use bot token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
@@ -56,7 +64,7 @@ jobs:
       - name: Generate semantic version for @algorandfoundation/algorand-typescript-testing
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Publish @algorandfoundation/algorand-typescript-testing
         uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
Utilizes a bot token instead of the default GITHUB_TOKEN for the release workflow.

