### PR TITLE
fix: abiCall throws unknown contract error for calls made to contracts with @contract decorator

### DIFF
--- a/src/abi-metadata.ts
+++ b/src/abi-metadata.ts
@@ -22,8 +22,14 @@ const metadataStore: WeakMap<{ new (): Contract }, Record<string, AbiMetadata>> 
 const contractSymbolMap: Map<string, symbol> = new Map()
 const contractMap: WeakMap<symbol, { new (): Contract }> = new WeakMap()
 /** @internal */
-export const attachAbiMetadata = (contract: { new (): Contract }, methodName: string, metadata: AbiMetadata, fileName: string): void => {
-  const contractFullName = `${fileName}::${contract.prototype.constructor.name}`
+export const attachAbiMetadata = (
+  contract: { new (): Contract },
+  methodName: string,
+  metadata: AbiMetadata,
+  fileName: string,
+  contractName: string,
+): void => {
+  const contractFullName = `${fileName}::${contractName}`
   if (!contractSymbolMap.has(contractFullName)) {
     contractSymbolMap.set(contractFullName, Symbol(contractFullName))
   }

--- a/src/test-transformer/node-factory.ts
+++ b/src/test-transformer/node-factory.ts
@@ -81,7 +81,13 @@ export const nodeFactory = {
       factory.createCallExpression(
         factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('attachAbiMetadata')),
         undefined,
-        [classIdentifier, methodName, metadata, factory.createStringLiteral(sourceFileName)],
+        [
+          classIdentifier,
+          methodName,
+          metadata,
+          factory.createStringLiteral(sourceFileName),
+          factory.createStringLiteral(classIdentifier.text),
+        ],
       ),
     )
   },

--- a/tests/arc4/abicall-decorated.algo.spec.ts
+++ b/tests/arc4/abicall-decorated.algo.spec.ts
@@ -1,0 +1,32 @@
+import { ApplicationSpy } from '@algorandfoundation/algorand-typescript-testing'
+import { methodSelector } from '@algorandfoundation/algorand-typescript/arc4'
+import { afterEach, describe, expect, test } from 'vitest'
+import { TestExecutionContext } from '../../src/test-execution-context'
+import { Hello } from '../artifacts/abicall-decorated/contract.algo'
+import { DecoratedGreeter } from '../artifacts/abicall-decorated/decorated-greeter.algo'
+
+describe('abicalll polytype ', () => {
+  const ctx = new TestExecutionContext()
+
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  test('test call contract one', async () => {
+    const greeter = ctx.contract.create(DecoratedGreeter)
+    const hello = ctx.contract.create(Hello)
+
+    const greeterApp = ctx.ledger.getApplicationForContract(greeter)
+
+    hello.createApplication(greeterApp)
+
+    const spy = new ApplicationSpy()
+    spy.onAbiCall(methodSelector(DecoratedGreeter.prototype.greet), (itxnContext) => {
+      itxnContext.setReturnValue('Hello, World, from Algorand')
+    })
+    ctx.addApplicationSpy(spy)
+
+    const result = hello.greet()
+    expect(result).toEqual('Hello, World, from Algorand')
+  })
+})

--- a/tests/artifacts/abicall-decorated/contract.algo.ts
+++ b/tests/artifacts/abicall-decorated/contract.algo.ts
@@ -1,0 +1,22 @@
+import type { Application } from '@algorandfoundation/algorand-typescript'
+import { Contract, GlobalState, abimethod } from '@algorandfoundation/algorand-typescript'
+import { abiCall } from '@algorandfoundation/algorand-typescript/arc4'
+import type { DecoratedGreeter } from './decorated-greeter.algo'
+
+export class Hello extends Contract {
+  greeterApp = GlobalState<Application>({ key: 'greeterApp' })
+
+  @abimethod({ onCreate: 'require' })
+  createApplication(greeterApp: Application): void {
+    this.greeterApp.value = greeterApp
+  }
+
+  greet(): string {
+    abiCall<typeof DecoratedGreeter.prototype.setGreeting>({ appId: this.greeterApp.value, args: ['Hello'] })
+    abiCall<typeof DecoratedGreeter.prototype.setName>({ appId: this.greeterApp.value, args: ['World'] })
+
+    const { returnValue } = abiCall<typeof DecoratedGreeter.prototype.greet>({ appId: this.greeterApp.value, args: ['from Algorand'] })
+
+    return returnValue
+  }
+}

--- a/tests/artifacts/abicall-decorated/decorated-greeter.algo.ts
+++ b/tests/artifacts/abicall-decorated/decorated-greeter.algo.ts
@@ -1,0 +1,22 @@
+import { abimethod, contract, Contract, GlobalState } from '@algorandfoundation/algorand-typescript'
+
+@contract({ name: 'Greeter', avmVersion: 11 })
+export class DecoratedGreeter extends Contract {
+  greeting = GlobalState({ initialValue: '' })
+  name = GlobalState({ initialValue: '' })
+
+  @abimethod()
+  setGreeting(greeting: string) {
+    this.greeting.value = greeting
+  }
+
+  @abimethod()
+  setName(name: string) {
+    this.name.value = name
+  }
+
+  @abimethod()
+  greet(from: string): string {
+    return `${this.greeting.value}, ${this.name.value}, ${from}`
+  }
+}

--- a/tests/artifacts/circurlar-reference/circular-reference-2.algo.ts
+++ b/tests/artifacts/circurlar-reference/circular-reference-2.algo.ts
@@ -1,8 +1,9 @@
 import type { Application } from '@algorandfoundation/algorand-typescript'
-import { Contract, log } from '@algorandfoundation/algorand-typescript'
+import { contract, Contract, log } from '@algorandfoundation/algorand-typescript'
 import { abiCall } from '@algorandfoundation/algorand-typescript/arc4'
 import type { ContractOne } from './circular-reference.algo'
 
+@contract({ name: 'ContractTwo' })
 export class ContractTwo extends Contract {
   test(appId: Application) {
     const result = abiCall<typeof ContractOne.prototype.receiver>({ appId, args: [appId] })

--- a/tests/artifacts/circurlar-reference/circular-reference.algo.ts
+++ b/tests/artifacts/circurlar-reference/circular-reference.algo.ts
@@ -1,8 +1,9 @@
 import type { Application } from '@algorandfoundation/algorand-typescript'
-import { Contract, log } from '@algorandfoundation/algorand-typescript'
+import { contract, Contract, log } from '@algorandfoundation/algorand-typescript'
 import { abiCall } from '@algorandfoundation/algorand-typescript/arc4'
 import type { ContractTwo } from './circular-reference-2.algo'
 
+@contract({ name: 'ContractOne' })
 export class ContractOne extends Contract {
   test(appId: Application) {
     const result = abiCall<typeof ContractTwo.prototype.receiver>({ appId, args: [appId] })


### PR DESCRIPTION
- do not use .prototype.constructor.name which can be changed during transpilation as per [this commit](https://github.com/evanw/esbuild/pull/3167/files#diff-47ba81a23cc6828c328cf8d6b3be85292b39bd7ed1032957067b80b7947bce39) in esbuild
- capture ClassDeclaration.name as contract name instead