### PR TITLE
fix: unsupported type error when cloning object with Account, Application or Asset property

### DIFF
--- a/examples/auction/contract.algo.spec.ts
+++ b/examples/auction/contract.algo.spec.ts
@@ -1,4 +1,4 @@
-import { OnCompleteAction, TransactionType } from '@algorandfoundation/algorand-typescript'
+import { TransactionType } from '@algorandfoundation/algorand-typescript'
 import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
 import { afterEach, describe, expect, it } from 'vitest'
 import { Auction } from './contract.algo'
@@ -139,9 +139,7 @@ describe('Auction', () => {
       contract.createApplication()
     })
 
-    ctx.txn.createScope([ctx.any.txn.applicationCall({ onCompletion: OnCompleteAction.DeleteApplication })]).execute(() => {
-      contract!.deleteApplication()
-    })
+    contract!.deleteApplication()
 
     // Assert
     const innerTransactions = ctx.txn.lastGroup.lastItxnGroup().getPaymentInnerTxn()

--- a/src/impl/base.ts
+++ b/src/impl/base.ts
@@ -15,12 +15,8 @@ export abstract class BytesBackedCls {
     this.#value = value
   }
 
-  static fromBytes<T extends BytesBackedCls>(
-    this: { new (v: bytes, typeInfo?: TypeInfo): T },
-    value: StubBytesCompat | Uint8Array,
-    typeInfo?: TypeInfo,
-  ) {
-    return new this(BytesCls.fromCompat(value).asAlgoTs(), typeInfo)
+  static fromBytes<T extends BytesBackedCls>(this: { new (v: bytes): T }, value: StubBytesCompat | Uint8Array) {
+    return new this(BytesCls.fromCompat(value).asAlgoTs())
   }
 }
 

--- a/src/impl/encoded-types/encoded-types.ts
+++ b/src/impl/encoded-types/encoded-types.ts
@@ -1424,7 +1424,7 @@ export const getEncoder = <T>(typeInfo: TypeInfo): fromBytes<T> => {
     )
   }
   const encoders: Record<string, fromBytes<DeliberateAny>> = {
-    account: (value, typeInfo) => AccountCls.fromBytes(value, typeInfo),
+    account: (value) => AccountCls.fromBytes(value),
     application: (value) => ApplicationCls.fromBytes(value),
     asset: (value) => AssetCls.fromBytes(value),
     boolean: booleanFromBytes,

--- a/src/impl/encoded-types/encoded-types.ts
+++ b/src/impl/encoded-types/encoded-types.ts
@@ -104,6 +104,7 @@ export class Uint<N extends BitSize> extends _Uint<N> implements _ARC4Encodedint
     assert(bigIntValue <= maxValue, `expected value <= ${maxValue}, got: ${bigIntValue}`)
 
     this._value = encodingUtil.bigIntToUint8Array(bigIntValue, maxBytesLength(this.bitSize))
+    setARC4TypeSymbol(this, `arc4.Uint<${this.bitSize}>`)
   }
 
   get native() {
@@ -177,6 +178,7 @@ export class UFixed<N extends BitSize, M extends number> extends _UFixed<N, M> i
     assert(bigIntValue <= maxValue, `expected value <= ${maxValue}, got: ${bigIntValue}`)
 
     this._value = encodingUtil.bigIntToUint8Array(bigIntValue, maxBytesLength(this.bitSize))
+    setARC4TypeSymbol(this, `arc4.UFixed<${this.bitSize}, ${this.precision}>`)
   }
 
   get native() {
@@ -229,6 +231,7 @@ export class Byte extends _Byte implements _ARC4Encodedint8Array {
     super(v)
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this._value = new Uint<8>(typeInfo, v)
+    setARC4TypeSymbol(this, `arc4.Uint<8>`)
   }
 
   asUint64() {
@@ -277,6 +280,7 @@ export class Str extends _Str implements _ARC4Encodedint8Array {
     const bytesLength = encodeLength(bytesValue.length.asNumber())
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this._value = asUint8Array(bytesLength.concat(bytesValue))
+    setARC4TypeSymbol(this, `arc4.Str`)
   }
   get native(): string {
     return encodingUtil.uint8ArrayToUtf8(this._value.slice(ABI_LENGTH_SIZE))
@@ -318,6 +322,7 @@ export class Bool extends _Bool implements _ARC4Encodedint8Array {
     super(v)
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this._value = encodingUtil.bigIntToUint8Array(v ? TRUE_BIGINT_VALUE : FALSE_BIGINT_VALUE, 1)
+    setARC4TypeSymbol(this, `arc4.Bool`)
   }
 
   get native(): boolean {
@@ -373,6 +378,7 @@ export class StaticArray<TItem extends _ARC4Encoded, TLength extends number>
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this.genericArgs = this.typeInfo.genericArgs as StaticArrayGenericArgs
     this.size = parseInt(this.genericArgs.size.name, 10)
+    setARC4TypeSymbol(this, `arc4.StaticArray<${this.genericArgs.elementType.name}, ${this.size}>`)
 
     // if we are not initialising from bytes, we need to check and set the items
     if (!isInitialisingFromBytes) {
@@ -491,6 +497,7 @@ export class Address extends _Address implements _ARC4Encodedint8Array {
 
     this._value = StaticArray.fromBytes(uint8ArrayValue, typeInfo) as StaticArray<Byte, 32>
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    setARC4TypeSymbol(this, `arc4.Address`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as Address
   }
 
@@ -552,6 +559,7 @@ export class DynamicArray<TItem extends _ARC4Encoded> extends _DynamicArray<TIte
     })
     this._value = items
 
+    setARC4TypeSymbol(this, `arc4.DynamicArray<${this.genericArgs.elementType.name}>`)
     return new Proxy(this, arrayProxyHandler<TItem>()) as DynamicArray<TItem>
   }
 
@@ -658,6 +666,7 @@ export class Tuple<TTuple extends [_ARC4Encoded, ..._ARC4Encoded[]]> extends _Tu
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     this.genericArgs = Object.values(this.typeInfo.genericArgs as Record<string, TypeInfo>)
 
+    setARC4TypeSymbol(this, `arc4.Tuple<${this.genericArgs.map((arg) => arg.name).join(', ')}>`)
     // if we are not initialising from bytes, we need to check and set the items
     if (!isInitialisingFromBytes) {
       assert(areAllARC4Encoded(items), 'expected ARC4 type')
@@ -747,6 +756,8 @@ export class Struct<T extends StructConstraint> extends (_Struct<StructConstrain
       })
     })
 
+    setARC4TypeSymbol(this, 'arc4.Struct')
+
     return new Proxy(this, {
       get(target, prop) {
         const originalValue = Reflect.get(target, prop)
@@ -825,6 +836,7 @@ export class DynamicBytes extends _DynamicBytes implements _ARC4Encodedint8Array
     const uint8ArrayValue = concatUint8Arrays(encodeLength(value?.length ?? 0).asUint8Array(), asUint8Array(value ?? new Uint8Array()))
     this._value = DynamicArray.fromBytes(uint8ArrayValue, typeInfo) as DynamicArray<Byte>
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    setARC4TypeSymbol(this, `arc4.DynamicBytes`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as DynamicBytes
   }
 
@@ -891,6 +903,7 @@ export class StaticBytes<TLength extends uint64 = 0> extends _StaticBytes<TLengt
     this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
     const uint8ArrayValue = asUint8Array(value ?? new Uint8Array(getMaxLengthOfStaticContentType(this.typeInfo)))
     this._value = StaticArray.fromBytes(uint8ArrayValue, typeInfo) as unknown as StaticArray<Byte, TLength>
+    setARC4TypeSymbol(this, `arc4.StaticBytes<${this._value.length}>`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as StaticBytes<TLength>
   }
 
@@ -1411,9 +1424,9 @@ export const getEncoder = <T>(typeInfo: TypeInfo): fromBytes<T> => {
     )
   }
   const encoders: Record<string, fromBytes<DeliberateAny>> = {
-    account: AccountCls.fromBytes,
-    application: ApplicationCls.fromBytes,
-    asset: AssetCls.fromBytes,
+    account: (value, typeInfo) => AccountCls.fromBytes(value, typeInfo),
+    application: (value) => ApplicationCls.fromBytes(value),
+    asset: (value) => AssetCls.fromBytes(value),
     boolean: booleanFromBytes,
     biguint: bigUintFromBytes,
     'bytes(<.*>)?': bytesFromBytes,
@@ -1449,4 +1462,10 @@ export const getEncoder = <T>(typeInfo: TypeInfo): fromBytes<T> => {
     throw new Error(`No encoder found for type ${typeInfo.name}`)
   }
   return encoder as fromBytes<T>
+}
+
+const setARC4TypeSymbol = (obj: DeliberateAny, value: string) => {
+  const symbol = Object.getOwnPropertySymbols(obj).find((s) => s.description === 'ARC4Type')
+  if (!symbol) return
+  obj[symbol] = value
 }

--- a/src/impl/encoded-types/utils.ts
+++ b/src/impl/encoded-types/utils.ts
@@ -54,6 +54,8 @@ export const getMaxLengthOfStaticContentType = (type: TypeInfo, asArc4Encoded: b
     }
   }
   switch (trimGenericTypeName(type.name)) {
+    case 'Application':
+    case 'Asset':
     case 'uint64':
       return UINT64_SIZE / BITS_IN_BYTE
     case 'biguint':
@@ -67,6 +69,8 @@ export const getMaxLengthOfStaticContentType = (type: TypeInfo, asArc4Encoded: b
       return parseInt((type.genericArgs as TypeInfo[])![0].name, 10) / BITS_IN_BYTE
     case 'UFixed':
       return parseInt((type.genericArgs as uFixedGenericArgs).n.name, 10) / BITS_IN_BYTE
+    case 'Account':
+      return 32
     case 'Address':
     case 'StaticBytes':
     case 'StaticArray':

--- a/src/impl/transactions.ts
+++ b/src/impl/transactions.ts
@@ -20,7 +20,7 @@ import { Account, Application, Asset } from './reference'
 
 /** @internal */
 const baseDefaultFields = () => ({
-  sender: lazyContext.defaultSender,
+  sender: lazyContext.hasActiveGroup ? lazyContext.activeApplication.address : lazyContext.defaultSender,
   fee: Uint64(0),
   firstValid: Uint64(0),
   firstValidTime: Uint64(0),

--- a/src/set-up.ts
+++ b/src/set-up.ts
@@ -1,7 +1,7 @@
 import { Address } from '@algorandfoundation/algorand-typescript/arc4'
 import { encodingUtil } from '@algorandfoundation/puya-ts'
 import { AlgoTsPrimitiveCls, BigUintCls, BytesCls, Uint64Cls } from './impl/primitives'
-import { AccountCls } from './impl/reference'
+import { AccountCls, ApplicationCls, AssetCls } from './impl/reference'
 
 type Tester = (this: TesterContext, a: unknown, b: unknown, customTesters: Array<Tester>) => boolean | undefined
 interface TesterContext {
@@ -137,6 +137,33 @@ function doAddEqualityTesters(expectObj: ExpectObj) {
       if (typeof subject === 'number') {
         const testValue = typeof test === 'bigint' ? test : undefined
         if (testValue !== undefined) return this.equals(BigInt(subject), testValue, customTesters)
+        return undefined
+      }
+      // Defer to other testers
+      return undefined
+    },
+    function AccountIsAccount(this: TesterContext, subject, test, customTesters): boolean | undefined {
+      if (subject instanceof AccountCls) {
+        const testValue = test instanceof AccountCls ? test : undefined
+        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
+        return undefined
+      }
+      // Defer to other testers
+      return undefined
+    },
+    function ApplicationIsApplication(this: TesterContext, subject, test, customTesters): boolean | undefined {
+      if (subject instanceof ApplicationCls) {
+        const testValue = test instanceof ApplicationCls ? test : undefined
+        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
+        return undefined
+      }
+      // Defer to other testers
+      return undefined
+    },
+    function AssetIsAsset(this: TesterContext, subject, test, customTesters): boolean | undefined {
+      if (subject instanceof AssetCls) {
+        const testValue = test instanceof AssetCls ? test : undefined
+        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
         return undefined
       }
       // Defer to other testers

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -245,7 +245,9 @@ export class ContractContext {
     return {
       construct(target, args) {
         let t: T | undefined = undefined
-        const application = lazyContext.any.application()
+        const application = lazyContext.any.application({
+          creator: lazyContext.hasActiveGroup ? lazyContext.activeGroup.activeTransaction.sender : lazyContext.defaultSender,
+        })
         const txn = lazyContext.any.txn.applicationCall({ appId: application })
         const appData = lazyContext.ledger.applicationDataMap.getOrFail(application.id)
         appData.isCreating = true

--- a/src/test-execution-context.ts
+++ b/src/test-execution-context.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TEMPLATE_VAR_PREFIX } from './constants'
 import { ContextManager } from './context-helpers/context-manager'
 import type { DecodedLogs, LogDecoding } from './decode-logs'
 import type { ApplicationCallInnerTxnContext } from './impl/inner-transactions'
-import { Account, AccountCls } from './impl/reference'
+import { AccountCls } from './impl/reference'
 import { ContractContext } from './subcontexts/contract-context'
 import { LedgerContext } from './subcontexts/ledger-context'
 import { TransactionContext } from './subcontexts/transaction-context'
@@ -109,7 +109,11 @@ export class TestExecutionContext {
    * @param {bytes | AccountType} val - The default sender account.
    */
   set defaultSender(val: bytes | AccountType) {
-    this.#defaultSender = val instanceof AccountCls ? val : Account(val as bytes)
+    if (val instanceof AccountCls) {
+      this.#defaultSender = val
+    } else if (this.#defaultSender.bytes !== val) {
+      this.#defaultSender = new AccountCls(val as bytes)
+    }
   }
 
   /**
@@ -236,6 +240,7 @@ export class TestExecutionContext {
     this.#compiledApps = []
     this.#compiledLogicSigs = []
     this.#applicationSpies = []
+    this.#defaultSender = this.any.account({ address: this.#defaultSender.bytes }) // reset default sender account data in ledger context
     ContextManager.reset()
     ContextManager.instance = this
   }

--- a/tests/native-mutable-object.algo.spec.ts
+++ b/tests/native-mutable-object.algo.spec.ts
@@ -1,4 +1,4 @@
-import type { bytes, uint64 } from '@algorandfoundation/algorand-typescript'
+import type { Account, Application, Asset, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
 import {
   arc4,
   assertMatch,
@@ -116,6 +116,20 @@ type Arc4TupleObj = {
   a: uint64
   b: arc4.Tuple<readonly [arc4.Uint64, arc4.Str, arc4.Bool]>
   c: string
+}
+
+type AccountWithVotes = {
+  account: Account
+  votes: arc4.Uint32
+}
+
+type ApplicationWithVotes = {
+  application: Application
+  votes: arc4.Uint32
+}
+type AssetWithVotes = {
+  asset: Asset
+  votes: arc4.Uint32
 }
 
 class TestContract extends Contract {
@@ -797,6 +811,50 @@ describe('native mutable object', () => {
 
       expect(clone(obj2)).toEqual(obj2)
       expect(clone(obj1)).toEqual(obj1)
+    })
+    it('should work for objects with account property', () => {
+      const account1: Account = ctx.any.account()
+      const account2: Account = ctx.any.account()
+      const obj1: AccountWithVotes = {
+        account: account1,
+        votes: new arc4.Uint32(100),
+      }
+      const obj2: AccountWithVotes = {
+        account: account2,
+        votes: new arc4.Uint32(200),
+      }
+      expect(clone(obj1)).toEqual(obj1)
+      expect(clone(obj2)).toEqual(obj2)
+    })
+    it('should work for objects with application property', () => {
+      const application1: Application = ctx.any.application()
+      const application2: Application = ctx.any.application()
+      const obj1: ApplicationWithVotes = {
+        application: application1,
+        votes: new arc4.Uint32(100),
+      }
+      const obj2: ApplicationWithVotes = {
+        application: application2,
+        votes: new arc4.Uint32(200),
+      }
+
+      expect(clone(obj1)).toEqual(obj1)
+      expect(clone(obj2)).toEqual(obj2)
+    })
+    it('should work for objects with asset property', () => {
+      const asset1: Asset = ctx.any.asset()
+      const asset2: Asset = ctx.any.asset()
+      const obj1: AssetWithVotes = {
+        asset: asset1,
+        votes: new arc4.Uint32(100),
+      }
+      const obj2: AssetWithVotes = {
+        asset: asset2,
+        votes: new arc4.Uint32(200),
+      }
+
+      expect(clone(obj1)).toEqual(obj1)
+      expect(clone(obj2)).toEqual(obj2)
     })
   })
 })

--- a/tests/references/arc4-contract.algo.spec.ts
+++ b/tests/references/arc4-contract.algo.spec.ts
@@ -79,11 +79,13 @@ describe('arc4 contract creation', () => {
     const arg1 = ctx.any.uint64()
     const sender = ctx.any.account()
 
-    const contract = ctx.contract.create(ContractARC4Create)
-    ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: ctx.ledger.getApplicationForContract(contract), sender })]).execute(() => {
-      contract.createApplication(arg1)
-      expect(contract.arg1).toEqual(arg1)
-      expect(contract.creator).toEqual(sender)
+    ctx.txn.createScope([ctx.any.txn.applicationCall({ sender })]).execute(() => {
+      const contract = ctx.contract.create(ContractARC4Create)
+      ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: ctx.ledger.getApplicationForContract(contract), sender })]).execute(() => {
+        contract.createApplication(arg1)
+        expect(contract.arg1).toEqual(arg1)
+        expect(contract.creator).toEqual(sender)
+      })
     })
   })
 


### PR DESCRIPTION
*Also*:
- improve equality tester for Account, Application, and Asset objects
- set `sender` of inner transactions to the calling contract's address by default (instead of always using the global default sender).
- set `creator` of the application to `sender` of the active transaction or global default sender when creating a contract (instead of leaving it unset).