### PR TITLE
fix: correct default sender for inner txns and creator for new contracts

### DIFF
--- a/examples/auction/contract.algo.spec.ts
+++ b/examples/auction/contract.algo.spec.ts
@@ -1,4 +1,4 @@
-import { OnCompleteAction, TransactionType } from '@algorandfoundation/algorand-typescript'
+import { TransactionType } from '@algorandfoundation/algorand-typescript'
 import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
 import { afterEach, describe, expect, it } from 'vitest'
 import { Auction } from './contract.algo'
@@ -139,9 +139,7 @@ describe('Auction', () => {
       contract.createApplication()
     })
 
-    ctx.txn.createScope([ctx.any.txn.applicationCall({ onCompletion: OnCompleteAction.DeleteApplication })]).execute(() => {
-      contract!.deleteApplication()
-    })
+    contract!.deleteApplication()
 
     // Assert
     const innerTransactions = ctx.txn.lastGroup.lastItxnGroup().getPaymentInnerTxn()

--- a/src/impl/transactions.ts
+++ b/src/impl/transactions.ts
@@ -20,7 +20,7 @@ import { Account, Application, Asset } from './reference'
 
 /** @internal */
 const baseDefaultFields = () => ({
-  sender: lazyContext.defaultSender,
+  sender: lazyContext.hasActiveGroup ? lazyContext.activeApplication.address : lazyContext.defaultSender,
   fee: Uint64(0),
   firstValid: Uint64(0),
   firstValidTime: Uint64(0),

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -245,7 +245,9 @@ export class ContractContext {
     return {
       construct(target, args) {
         let t: T | undefined = undefined
-        const application = lazyContext.any.application()
+        const application = lazyContext.any.application({
+          creator: lazyContext.hasActiveGroup ? lazyContext.activeGroup.activeTransaction.sender : lazyContext.defaultSender,
+        })
         const txn = lazyContext.any.txn.applicationCall({ appId: application })
         const appData = lazyContext.ledger.applicationDataMap.getOrFail(application.id)
         appData.isCreating = true

--- a/tests/references/arc4-contract.algo.spec.ts
+++ b/tests/references/arc4-contract.algo.spec.ts
@@ -79,11 +79,13 @@ describe('arc4 contract creation', () => {
     const arg1 = ctx.any.uint64()
     const sender = ctx.any.account()
 
-    const contract = ctx.contract.create(ContractARC4Create)
-    ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: ctx.ledger.getApplicationForContract(contract), sender })]).execute(() => {
-      contract.createApplication(arg1)
-      expect(contract.arg1).toEqual(arg1)
-      expect(contract.creator).toEqual(sender)
+    ctx.txn.createScope([ctx.any.txn.applicationCall({ sender })]).execute(() => {
+      const contract = ctx.contract.create(ContractARC4Create)
+      ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: ctx.ledger.getApplicationForContract(contract), sender })]).execute(() => {
+        contract.createApplication(arg1)
+        expect(contract.arg1).toEqual(arg1)
+        expect(contract.creator).toEqual(sender)
+      })
     })
   })
 


### PR DESCRIPTION
- set `sender` of inner transactions to the calling contract's address by default; instead of always using the global default sender
- set `creator` of the application to sender of the active transaction or global default sender when creating a contract; instead of leaving it unset