### PR TITLE
fix: remove job-level permissions override from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,6 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - name: Generate bot token
         uses: actions/create-github-app-token@v3
@@ -56,7 +54,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci --ignore-scripts
 


### PR DESCRIPTION
## Summary

- Job-level `permissions: id-token: write` was overriding the workflow-level permissions, leaving the release job with only `metadata: read`, causing `semantic-release` to fail
- Removed the job-level override so the release job inherits all workflow-level permissions (`contents: write`, `issues: write`, `pull-requests: write`, `id-token: write`)
- Removed unnecessary `registry-url` from `setup-node` since publishing uses `JS-DevTools/npm-publish` with OIDC, not `npm publish` directly