### PR TITLE
chore: tidy and clean up

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -14,5 +14,9 @@
   "GHSA-f886-m6hf-6m8v": {
     "active": true,
     "notes": "Zero-step sequence causes process hang and memory exhaustion in brace-expansion. Transitive dependency via npm internals (npm > brace-expansion)."
+  },
+  "GHSA-v2v4-37r5-5v8g": {
+    "active": true,
+    "notes": "XSS in Address6 HTML-emitting methods in ip-address. Transitive dependency via npm internals (npm > ip-address); not invoked in this project."
   }
 }

--- a/src/abi-metadata.ts
+++ b/src/abi-metadata.ts
@@ -19,9 +19,8 @@ export interface AbiMetadata {
   resourceEncoding?: arc4.ResourceEncodingOptions
 }
 
-const metadataStore: WeakMap<{ new (): Contract }, Record<string, AbiMetadata>> = new WeakMap()
-const contractSymbolMap: Map<string, symbol> = new Map()
-const contractMap: WeakMap<symbol, { new (): Contract }> = new WeakMap()
+const metadataStore: Map<{ new (): Contract }, Record<string, AbiMetadata>> = new Map()
+const contractMap: Map<string, { new (): Contract }> = new Map()
 /** @internal */
 export const attachAbiMetadata = (
   contract: { new (): Contract },
@@ -31,28 +30,21 @@ export const attachAbiMetadata = (
   contractName: string,
 ): void => {
   const contractFullName = `${fileName}::${contractName}`
-  if (!contractSymbolMap.has(contractFullName)) {
-    contractSymbolMap.set(contractFullName, Symbol(contractFullName))
+  if (!contractMap.has(contractFullName)) {
+    contractMap.set(contractFullName, contract)
   }
-  const contractSymbol = contractSymbolMap.get(contractFullName)!
-  if (!contractMap.has(contractSymbol)) {
-    contractMap.set(contractSymbol, contract)
+  let storedMetadata = metadataStore.get(contract)
+  if (!storedMetadata) {
+    storedMetadata = {}
+    metadataStore.set(contract, storedMetadata)
   }
-  if (!metadataStore.has(contract)) {
-    metadataStore.set(contract, {})
-  }
-  const metadatas: Record<string, AbiMetadata> = metadataStore.get(contract) as Record<string, AbiMetadata>
+
   const conventionalRoutingConfig = getConventionalRoutingConfig(methodName)
-  metadatas[methodName] = {
+  storedMetadata[methodName] = {
     ...metadata,
     allowActions: metadata.allowActions ?? conventionalRoutingConfig?.allowActions,
     onCreate: metadata.onCreate ?? conventionalRoutingConfig?.onCreate,
   }
-}
-
-export const getContractByName = (contractFullname: string): { new (): Contract } | undefined => {
-  const contractSymbol = contractSymbolMap.get(contractFullname)
-  return !contractSymbol ? undefined : contractMap.get(contractSymbol)
 }
 
 /** @internal */
@@ -64,14 +56,13 @@ export const getContractAbiMetadata = <T extends Contract>(contract: T | { new (
   let currentClass = contract instanceof Contract ? (contract.constructor as { new (): T }) : contract
 
   // Walk up the prototype chain
-  while (currentClass && currentClass.prototype) {
+  while (currentClass) {
     // Find metadata for current class
     const currentMetadata = metadataStore.get(currentClass)
 
     if (currentMetadata) {
       // Merge metadata with existing result (don't override existing entries)
-      const classMetadata = currentMetadata
-      for (const [methodName, metadata] of Object.entries(classMetadata)) {
+      for (const [methodName, metadata] of Object.entries(currentMetadata)) {
         if (!(methodName in result)) {
           result[methodName] = {
             ...metadata,
@@ -94,27 +85,24 @@ export const getContractMethodAbiMetadata = <T extends Contract>(contract: T | {
   return metadatas[methodName]
 }
 
-/** @internal */
-export const getArc4Signature = (metadata: AbiMetadata): string => {
-  if (metadata.methodSignature === undefined) {
-    const argTypes = metadata.argTypes.map((t) => JSON.parse(t) as TypeInfo).map((t) => getArc4TypeName(t, metadata.resourceEncoding, 'in'))
-    const returnType = getArc4TypeName(JSON.parse(metadata.returnType) as TypeInfo, metadata.resourceEncoding, 'out')
-    metadata.methodSignature = `${metadata.name ?? metadata.methodName}(${argTypes.join(',')})${returnType}`
-  }
-  return metadata.methodSignature
+const computeArc4Signature = (metadata: AbiMetadata): string => {
+  const argTypes = metadata.argTypes.map((t) => JSON.parse(t) as TypeInfo).map((t) => getArc4TypeName(t, metadata.resourceEncoding, 'in'))
+  const returnType = getArc4TypeName(JSON.parse(metadata.returnType) as TypeInfo, metadata.resourceEncoding, 'out')
+  return `${metadata.name ?? metadata.methodName}(${argTypes.join(',')})${returnType}`
 }
 
 /** @internal */
 export const getArc4Selector = (metadata: AbiMetadata): Uint8Array => {
-  const hash = js_sha512.sha512_256.array(getArc4Signature(metadata))
+  metadata.methodSignature ??= computeArc4Signature(metadata)
+  const hash = js_sha512.sha512_256.array(metadata.methodSignature)
   return new Uint8Array(hash.slice(0, 4))
 }
 
 /** @internal */
 export const getContractMethod = (contractFullName: string, methodName: string) => {
-  const contract = getContractByName(contractFullName)
+  const contract = contractMap.get(contractFullName)
 
-  if (contract === undefined || typeof contract !== 'function') {
+  if (contract === undefined) {
     throw new InternalError(`Unknown contract: ${contractFullName}`)
   }
 

--- a/src/abi-metadata.ts
+++ b/src/abi-metadata.ts
@@ -118,7 +118,7 @@ export const getContractMethod = (contractFullName: string, methodName: string) 
     throw new InternalError(`Unknown contract: ${contractFullName}`)
   }
 
-  if (!Object.hasOwn(contract.prototype, methodName)) {
+  if (!(methodName in contract.prototype)) {
     throw new InternalError(`Unknown method: ${methodName} in contract: ${contractFullName}`)
   }
 

--- a/src/impl/c2c.ts
+++ b/src/impl/c2c.ts
@@ -18,9 +18,9 @@ export function compileArc4<TContract extends Contract>(
   options?: CompileContractOptions,
 ): ContractProxy<TContract> {
   let app: ApplicationData | undefined
-  const compiledAppEntry = lazyContext.value.getCompiledAppEntry(contract)
-  if (compiledAppEntry !== undefined) {
-    app = lazyContext.ledger.applicationDataMap.get(compiledAppEntry.value)
+  const compiledAppId = lazyContext.value.getCompiledApp(contract)
+  if (compiledAppId !== undefined) {
+    app = lazyContext.ledger.applicationDataMap.get(compiledAppId)
   }
 
   if (options?.templateVars) {

--- a/src/impl/compiled.ts
+++ b/src/impl/compiled.ts
@@ -18,13 +18,13 @@ export function compile(
 ): CompiledLogicSig | CompiledContract {
   let app: ApplicationData | undefined
   let account: Account | undefined
-  const compiledAppEntry = lazyContext.value.getCompiledAppEntry(artefact as ConstructorFor<BaseContract>)
-  const compiledLogicSigEntry = lazyContext.value.getCompiledLogicSigEntry(artefact as ConstructorFor<LogicSig>)
-  if (compiledAppEntry !== undefined) {
-    app = lazyContext.ledger.applicationDataMap.get(compiledAppEntry.value)
+  const compiledAppId = lazyContext.value.getCompiledApp(artefact as ConstructorFor<BaseContract>)
+  const compiledLogicSigAccount = lazyContext.value.getCompiledLogicSig(artefact as ConstructorFor<LogicSig>)
+  if (compiledAppId !== undefined) {
+    app = lazyContext.ledger.applicationDataMap.get(compiledAppId)
   }
-  if (compiledLogicSigEntry !== undefined) {
-    account = compiledLogicSigEntry.value
+  if (compiledLogicSigAccount !== undefined) {
+    account = compiledLogicSigAccount
   }
   if (options?.templateVars) {
     Object.entries(options.templateVars).forEach(([key, value]) => {

--- a/src/impl/encoded-types/encoded-types.ts
+++ b/src/impl/encoded-types/encoded-types.ts
@@ -28,7 +28,6 @@ import {
 import { AvmError, avmInvariant, CodeError, InternalError } from '../../errors'
 import { nameOfType, type DeliberateAny } from '../../typescript-helpers'
 import {
-  asBigInt,
   asBigUint,
   asBigUintCls,
   asBytes,
@@ -38,6 +37,7 @@ import {
   asMaybeUint64Cls,
   asNumber,
   asUint64,
+  asUint64BigInt,
   asUint64Cls,
   asUint8Array,
   concatUint8Arrays,
@@ -1257,7 +1257,7 @@ export const getArc4Encoded = (value: DeliberateAny, sourceTypeInfoString?: stri
     return new Bool({ name: 'Bool' }, value)
   }
   if (value instanceof Uint64Cls || typeof value === 'number') {
-    return new Uint({ name: 'Uint<64>', genericArgs: [{ name: '64' }] }, asBigInt(value))
+    return new Uint({ name: 'Uint<64>', genericArgs: [{ name: '64' }] }, asUint64BigInt(value))
   }
   if (value instanceof BigUintCls) {
     return new Uint({ name: 'Uint<512>', genericArgs: [{ name: '512' }] }, value.asBigInt())

--- a/src/impl/encoded-types/encoded-types.ts
+++ b/src/impl/encoded-types/encoded-types.ts
@@ -18,20 +18,13 @@ import {
 } from '@algorandfoundation/algorand-typescript/arc4'
 import { encodingUtil } from '@algorandfoundation/puya-ts'
 import assert from 'assert'
-import {
-  ABI_RETURN_VALUE_LOG_PREFIX,
-  ALGORAND_ADDRESS_BYTE_LENGTH,
-  ALGORAND_CHECKSUM_BYTE_LENGTH,
-  MAX_UINT64,
-  UINT64_SIZE,
-} from '../../constants'
+import { ALGORAND_ADDRESS_BYTE_LENGTH, ALGORAND_CHECKSUM_BYTE_LENGTH, MAX_UINT64, UINT64_SIZE } from '../../constants'
 import { AvmError, avmInvariant, CodeError, InternalError } from '../../errors'
 import { nameOfType, type DeliberateAny } from '../../typescript-helpers'
 import {
   asBigUint,
   asBigUintCls,
   asBytes,
-  asBytesCls,
   asMaybeBigUintCls,
   asMaybeBytesCls,
   asMaybeUint64Cls,
@@ -50,7 +43,10 @@ import { Account, AccountCls, ApplicationCls, AssetCls } from '../reference'
 import { arrayProxyHandler } from './array-proxy'
 import { ABI_LENGTH_SIZE, FALSE_BIGINT_VALUE, IS_INITIALISING_FROM_BYTES_SYMBOL, TRUE_BIGINT_VALUE } from './constants'
 import {
+  accountFromBytes,
+  applicationFromBytes,
   areAllARC4Encoded,
+  assetFromBytes,
   bigUintFromBytes,
   booleanFromBytes,
   bytesFromBytes,
@@ -67,6 +63,7 @@ import {
   readLength,
   regExpNxM,
   stringFromBytes,
+  stripLogPrefix,
   transactionTypeFromBytes,
   trimTrailingDecimalZeros,
   uint64FromBytes,
@@ -86,6 +83,16 @@ import { getMaxLengthOfStaticContentType } from './utils'
 interface _ARC4Encodedint8Array extends _ARC4Encoded {
   get uint8ArrayValue(): Uint8Array
 }
+
+const parseTypeInfo = (typeInfo: TypeInfo | string): TypeInfo => (typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo)
+
+const collectEntries = <T>(target: T[], other: { entries(): { next(): IteratorResult<readonly [unknown, unknown]> } }): void => {
+  const it = other.entries()
+  for (let next = it.next(); !next.done; next = it.next()) {
+    target.push(next.value[1] as T)
+  }
+}
+
 /** @internal */
 export class Uint<N extends BitSize> extends _Uint<N> implements _ARC4Encodedint8Array {
   private _value: Uint8Array
@@ -94,7 +101,7 @@ export class Uint<N extends BitSize> extends _Uint<N> implements _ARC4Encodedint
 
   constructor(typeInfo: TypeInfo | string, v?: CompatForArc4Int<N>) {
     super()
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.bitSize = Uint.getMaxBitsLength(this.typeInfo) as N
 
     assert(validBitSizes.includes(this.bitSize), `Invalid bit size ${this.bitSize}`)
@@ -141,13 +148,8 @@ export class Uint<N extends BitSize> extends _Uint<N> implements _ARC4Encodedint
   }
 
   static fromBytes(value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none'): Uint<BitSize> {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     const result = new Uint<BitSize>(typeInfo)
-    result._value = asUint8Array(bytesValue)
+    result._value = stripLogPrefix(value, prefix)
     return result
   }
 
@@ -165,19 +167,23 @@ export class UFixed<N extends BitSize, M extends number> extends _UFixed<N, M> i
 
   constructor(typeInfo: TypeInfo | string, v?: `${number}.${number}`) {
     super(v)
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     const genericArgs = this.typeInfo.genericArgs as uFixedGenericArgs
     this.bitSize = UFixed.getMaxBitsLength(this.typeInfo) as N
     this.precision = parseInt(genericArgs.m.name, 10) as M
 
-    const trimmedValue = trimTrailingDecimalZeros(v ?? '0.0')
-    assert(regExpNxM(this.precision).test(trimmedValue), `expected positive decimal literal with max of ${this.precision} decimal places`)
+    if (v === undefined) {
+      this._value = new Uint8Array(maxBytesLength(this.bitSize))
+    } else {
+      const trimmedValue = trimTrailingDecimalZeros(v)
+      assert(regExpNxM(this.precision).test(trimmedValue), `expected positive decimal literal with max of ${this.precision} decimal places`)
 
-    const bigIntValue = BigInt(trimmedValue.replace('.', ''))
-    const maxValue = maxBigIntValue(this.bitSize)
-    assert(bigIntValue <= maxValue, `expected value <= ${maxValue}, got: ${bigIntValue}`)
+      const bigIntValue = BigInt(trimmedValue.replace('.', ''))
+      const maxValue = maxBigIntValue(this.bitSize)
+      assert(bigIntValue <= maxValue, `expected value <= ${maxValue}, got: ${bigIntValue}`)
 
-    this._value = encodingUtil.bigIntToUint8Array(bigIntValue, maxBytesLength(this.bitSize))
+      this._value = encodingUtil.bigIntToUint8Array(bigIntValue, maxBytesLength(this.bitSize))
+    }
     setARC4TypeSymbol(this, `arc4.UFixed<${this.bitSize}, ${this.precision}>`)
   }
 
@@ -206,13 +212,8 @@ export class UFixed<N extends BitSize, M extends number> extends _UFixed<N, M> i
     typeInfo: string | TypeInfo,
     prefix: 'none' | 'log' = 'none',
   ): _UFixed<BitSize, number> {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
-    const result = new UFixed<BitSize, number>(typeInfo, '0.0')
-    result._value = asUint8Array(bytesValue)
+    const result = new UFixed<BitSize, number>(typeInfo)
+    result._value = stripLogPrefix(value, prefix)
     return result
   }
 
@@ -229,7 +230,7 @@ export class Byte extends _Byte implements _ARC4Encodedint8Array {
 
   constructor(typeInfo: TypeInfo | string, v?: CompatForArc4Int<8>) {
     super(v)
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this._value = new Uint<8>(typeInfo, v)
     setARC4TypeSymbol(this, `arc4.Uint<8>`)
   }
@@ -276,10 +277,12 @@ export class Str extends _Str implements _ARC4Encodedint8Array {
 
   constructor(typeInfo: TypeInfo | string, s?: StringCompat) {
     super()
-    const bytesValue = asBytesCls(s ?? '')
-    const bytesLength = encodeLength(bytesValue.length.asNumber())
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
-    this._value = asUint8Array(bytesLength.concat(bytesValue))
+    this.typeInfo = parseTypeInfo(typeInfo)
+
+    const uint8ArrayValue = asUint8Array(s ?? '')
+    const bytesLength = asUint8Array(encodeLength(uint8ArrayValue.length))
+    this._value = concatUint8Arrays(bytesLength, uint8ArrayValue)
+
     setARC4TypeSymbol(this, `arc4.Str`)
   }
   get native(): string {
@@ -302,13 +305,8 @@ export class Str extends _Str implements _ARC4Encodedint8Array {
   }
 
   static fromBytes(value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none'): Str {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     const result = new Str(typeInfo)
-    result._value = asUint8Array(bytesValue)
+    result._value = stripLogPrefix(value, prefix)
     return result
   }
 }
@@ -320,7 +318,7 @@ export class Bool extends _Bool implements _ARC4Encodedint8Array {
 
   constructor(typeInfo: TypeInfo | string, v?: boolean) {
     super(v)
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this._value = encodingUtil.bigIntToUint8Array(v ? TRUE_BIGINT_VALUE : FALSE_BIGINT_VALUE, 1)
     setARC4TypeSymbol(this, `arc4.Bool`)
   }
@@ -345,13 +343,8 @@ export class Bool extends _Bool implements _ARC4Encodedint8Array {
   }
 
   static fromBytes(value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none'): Bool {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     const result = new Bool(typeInfo)
-    result._value = asUint8Array(bytesValue)
+    result._value = stripLogPrefix(value, prefix)
     return result
   }
 }
@@ -375,7 +368,7 @@ export class StaticArray<TItem extends _ARC4Encoded, TLength extends number>
     const isInitialisingFromBytes = items.length === 1 && (items[0] as DeliberateAny) === IS_INITIALISING_FROM_BYTES_SYMBOL
     super()
 
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.genericArgs = this.typeInfo.genericArgs as StaticArrayGenericArgs
     this.size = parseInt(this.genericArgs.size.name, 10)
     setARC4TypeSymbol(this, `arc4.StaticArray<${this.genericArgs.elementType.name}, ${this.size}>`)
@@ -443,12 +436,7 @@ export class StaticArray<TItem extends _ARC4Encoded, TLength extends number>
 
   concat(other: Parameters<InstanceType<typeof _StaticArray>['concat']>[0]): DynamicArray<TItem> {
     const items = this.items
-    const otherEntries = other.entries()
-    let next = otherEntries.next()
-    while (!next.done) {
-      items.push(next.value[1] as TItem)
-      next = otherEntries.next()
-    }
+    collectEntries(items, other)
     return new DynamicArray<TItem>(
       { name: `DynamicArray<${this.genericArgs.elementType.name}>`, genericArgs: { elementType: this.genericArgs.elementType } },
       ...items,
@@ -464,14 +452,9 @@ export class StaticArray<TItem extends _ARC4Encoded, TLength extends number>
     typeInfo: string | TypeInfo,
     prefix: 'none' | 'log' = 'none',
   ): StaticArray<_ARC4Encoded, number> {
-    let bytesValue = value instanceof Uint8Array ? value : asUint8Array(value)
-    if (prefix === 'log') {
-      assert(Bytes(bytesValue.slice(0, 4)).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     // pass the symbol to the constructor to let it know we are initialising from bytes
     const result = new StaticArray<_ARC4Encoded, number>(typeInfo, IS_INITIALISING_FROM_BYTES_SYMBOL as DeliberateAny)
-    result._uint8ArrayValue = bytesValue
+    result._uint8ArrayValue = stripLogPrefix(value, prefix)
     return result
   }
 }
@@ -495,8 +478,9 @@ export class Address extends _Address implements _ARC4Encodedint8Array {
     }
     avmInvariant(uint8ArrayValue.length === 32, 'Addresses should be 32 bytes')
 
-    this._value = StaticArray.fromBytes(uint8ArrayValue, typeInfo) as StaticArray<Byte, 32>
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
+    this._value = StaticArray.fromBytes(uint8ArrayValue, this.typeInfo) as StaticArray<Byte, 32>
+
     setARC4TypeSymbol(this, `arc4.Address`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as Address
   }
@@ -549,7 +533,7 @@ export class DynamicArray<TItem extends _ARC4Encoded> extends _DynamicArray<TIte
 
   constructor(typeInfo: TypeInfo | string, ...items: TItem[]) {
     super()
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.genericArgs = this.typeInfo.genericArgs as DynamicArrayGenericArgs
 
     assert(areAllARC4Encoded(items), 'expected ARC4 type')
@@ -622,12 +606,7 @@ export class DynamicArray<TItem extends _ARC4Encoded> extends _DynamicArray<TIte
 
   concat(other: Parameters<InstanceType<typeof _DynamicArray>['concat']>[0]): DynamicArray<TItem> {
     const items = this.items
-    const otherEntries = other.entries()
-    let next = otherEntries.next()
-    while (!next.done) {
-      items.push(next.value[1] as TItem)
-      next = otherEntries.next()
-    }
+    collectEntries(items, other)
     return new DynamicArray<TItem>(this.typeInfo, ...items)
   }
 
@@ -636,13 +615,8 @@ export class DynamicArray<TItem extends _ARC4Encoded> extends _DynamicArray<TIte
     typeInfo: string | TypeInfo,
     prefix: 'none' | 'log' = 'none',
   ): DynamicArray<_ARC4Encoded> {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     const result = new DynamicArray(typeInfo)
-    result._uint8ArrayValue = asUint8Array(bytesValue)
+    result._uint8ArrayValue = stripLogPrefix(value, prefix)
     return result
   }
 
@@ -663,7 +637,7 @@ export class Tuple<TTuple extends [_ARC4Encoded, ..._ARC4Encoded[]]> extends _Tu
     // so we don't need to pass the items to the super constructor
     const isInitialisingFromBytes = items.length === 1 && (items[0] as DeliberateAny) === IS_INITIALISING_FROM_BYTES_SYMBOL
     super(...(isInitialisingFromBytes ? ([] as DeliberateAny) : items))
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.genericArgs = Object.values(this.typeInfo.genericArgs as Record<string, TypeInfo>)
 
     setARC4TypeSymbol(this, `arc4.Tuple<${this.genericArgs.map((arg) => arg.name).join(', ')}>`)
@@ -726,14 +700,9 @@ export class Tuple<TTuple extends [_ARC4Encoded, ..._ARC4Encoded[]]> extends _Tu
     typeInfo: string | TypeInfo,
     prefix: 'none' | 'log' = 'none',
   ): Tuple<[_ARC4Encoded, ..._ARC4Encoded[]]> {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     // pass the symbol to the constructor to let it know we are initialising from bytes
     const result = new Tuple(typeInfo, IS_INITIALISING_FROM_BYTES_SYMBOL as DeliberateAny)
-    result._uint8ArrayValue = asUint8Array(bytesValue)
+    result._uint8ArrayValue = stripLogPrefix(value, prefix)
     return result
   }
 }
@@ -745,7 +714,7 @@ export class Struct<T extends StructConstraint> extends (_Struct<StructConstrain
 
   constructor(typeInfo: TypeInfo | string, value: T = {} as T) {
     super(value)
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.genericArgs = this.typeInfo.genericArgs as Record<string, TypeInfo>
 
     Object.keys(this.genericArgs).forEach((key) => {
@@ -815,13 +784,8 @@ export class Struct<T extends StructConstraint> extends (_Struct<StructConstrain
     typeInfo: string | TypeInfo,
     prefix: 'none' | 'log' = 'none',
   ): Struct<StructConstraint> {
-    let bytesValue = asBytesCls(value)
-    if (prefix === 'log') {
-      assert(bytesValue.slice(0, 4).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
-      bytesValue = bytesValue.slice(4)
-    }
     const result = new Struct(typeInfo)
-    result._uint8ArrayValue = asUint8Array(bytesValue)
+    result._uint8ArrayValue = stripLogPrefix(value, prefix)
     return result
   }
 }
@@ -833,9 +797,11 @@ export class DynamicBytes extends _DynamicBytes implements _ARC4Encodedint8Array
 
   constructor(typeInfo: TypeInfo | string, value?: bytes | string) {
     super(value)
+    this.typeInfo = parseTypeInfo(typeInfo)
+
     const uint8ArrayValue = concatUint8Arrays(encodeLength(value?.length ?? 0).asUint8Array(), asUint8Array(value ?? new Uint8Array()))
-    this._value = DynamicArray.fromBytes(uint8ArrayValue, typeInfo) as DynamicArray<Byte>
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this._value = DynamicArray.fromBytes(uint8ArrayValue, this.typeInfo) as DynamicArray<Byte>
+
     setARC4TypeSymbol(this, `arc4.DynamicBytes`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as DynamicBytes
   }
@@ -873,12 +839,7 @@ export class DynamicBytes extends _DynamicBytes implements _ARC4Encodedint8Array
 
   concat(other: Parameters<InstanceType<typeof _DynamicBytes>['concat']>[0]): DynamicBytes {
     const items = this.items
-    const otherEntries = other.entries()
-    let next = otherEntries.next()
-    while (!next.done) {
-      items.push(next.value[1] as Byte)
-      next = otherEntries.next()
-    }
+    collectEntries(items, other)
     const concatenatedBytes = items
       .map((item) => item.uint8ArrayValue)
       .reduce((acc, curr) => concatUint8Arrays(acc, curr), new Uint8Array())
@@ -900,9 +861,11 @@ export class StaticBytes<TLength extends uint64 = 0> extends _StaticBytes<TLengt
 
   constructor(typeInfo: TypeInfo | string, value?: bytes<TLength>) {
     super(value ?? (Bytes() as bytes<TLength>))
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
+
     const uint8ArrayValue = asUint8Array(value ?? new Uint8Array(getMaxLengthOfStaticContentType(this.typeInfo)))
-    this._value = StaticArray.fromBytes(uint8ArrayValue, typeInfo) as unknown as StaticArray<Byte, TLength>
+    this._value = StaticArray.fromBytes(uint8ArrayValue, this.typeInfo) as unknown as StaticArray<Byte, TLength>
+
     setARC4TypeSymbol(this, `arc4.StaticBytes<${this._value.length}>`)
     return new Proxy(this, arrayProxyHandler<Byte>()) as StaticBytes<TLength>
   }
@@ -940,12 +903,7 @@ export class StaticBytes<TLength extends uint64 = 0> extends _StaticBytes<TLengt
 
   concat(other: Parameters<InstanceType<typeof _StaticBytes>['concat']>[0]): DynamicBytes {
     const items = this.items
-    const otherEntries = other.entries()
-    let next = otherEntries.next()
-    while (!next.done) {
-      items.push(next.value[1] as Byte)
-      next = otherEntries.next()
-    }
+    collectEntries(items, other)
     const concatenatedBytes = items
       .map((item) => item.uint8ArrayValue)
       .reduce((acc, curr) => concatUint8Arrays(acc, curr), new Uint8Array())
@@ -967,7 +925,7 @@ export class ReferenceArray<TItem> extends _ReferenceArray<TItem> {
 
   constructor(typeInfo: TypeInfo | string, ...items: TItem[]) {
     super(...items)
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this._values = items
 
     return new Proxy(this, arrayProxyHandler<TItem>()) as ReferenceArray<TItem>
@@ -1006,7 +964,9 @@ export class ReferenceArray<TItem> extends _ReferenceArray<TItem> {
    * Pop a single item from this array
    */
   pop(): TItem {
-    return this._values.pop()!
+    const popped = this._values.pop()
+    if (popped === undefined) throw new AvmError('The array is empty')
+    return popped
   }
 
   copy(): _ReferenceArray<TItem> {
@@ -1024,7 +984,7 @@ export class FixedArray<TItem, TLength extends number> extends _FixedArray<TItem
 
   constructor(typeInfo: TypeInfo | string, ...items: TItem[] & { length: TLength }) {
     super()
-    this.typeInfo = typeof typeInfo === 'string' ? JSON.parse(typeInfo) : typeInfo
+    this.typeInfo = parseTypeInfo(typeInfo)
     this.genericArgs = this.typeInfo.genericArgs as StaticArrayGenericArgs
     this.size = parseInt(this.genericArgs.size.name, 10)
     if (items.length) {
@@ -1087,7 +1047,7 @@ const decode = (value: Uint8Array, childTypes: TypeInfo[], isHomogenous?: boolea
       const before = findBoolTypes(childTypes, i, -1, isHomogenous)
       let after = findBoolTypes(childTypes, i, 1, isHomogenous)
 
-      if (before % 8 != 0) {
+      if (before % 8 !== 0) {
         throw new CodeError('"expected before index should have number of bool mod 8 equal 0"')
       }
       after = Math.min(7, after)
@@ -1108,7 +1068,7 @@ const decode = (value: Uint8Array, childTypes: TypeInfo[], isHomogenous?: boolea
       arrayIndex += currLen
     }
 
-    if (arrayIndex >= value.length && i != childTypes.length - 1) {
+    if (arrayIndex >= value.length && i !== childTypes.length - 1) {
       throw new CodeError('input string is not long enough to be decoded')
     }
     i += 1
@@ -1134,9 +1094,11 @@ const decode = (value: Uint8Array, childTypes: TypeInfo[], isHomogenous?: boolea
 
   const values: _ARC4Encoded[] = []
   childTypes.forEach((childType, index) => {
+    // Native `bytes` and `string` decoders treat their input as raw content, so the ABI length prefix must be stripped here;
+    // ARC4 dynamic types (Str, DynamicBytes, DynamicArray, ...) keep the prefix in their stored value.
     values.push(
       getEncoder<_ARC4Encoded>(childType)(
-        ['bytes', 'string'].includes(childType.name) ? valuePartitions[index].slice(2) : valuePartitions[index],
+        ['bytes', 'string'].includes(childType.name) ? valuePartitions[index].slice(ABI_LENGTH_SIZE) : valuePartitions[index],
         childType,
       ),
     )
@@ -1144,25 +1106,25 @@ const decode = (value: Uint8Array, childTypes: TypeInfo[], isHomogenous?: boolea
   return values
 }
 
+const HEAD_PLACEHOLDER = new Uint8Array(ABI_LENGTH_SIZE) // Placeholder for head of dynamic types when encoding
 const encode = (values: (_ARC4Encoded & { uint8ArrayValue?: Uint8Array })[], isHomogenous?: boolean) => {
   const length = values.length
   const heads = []
   const tails = []
   const dynamicLengthTypeIndex = []
   let i = 0
-  const valuesLengthBytes = values instanceof _DynamicArray ? encodeLength(length).asUint8Array() : new Uint8Array()
   while (i < length) {
     const value = values[i]
     assert(value instanceof _ARC4Encoded, `expected ARC4 type ${value.constructor.name}`)
     dynamicLengthTypeIndex.push(isDynamicLengthType(value))
     if (dynamicLengthTypeIndex.at(-1)) {
-      heads.push(asUint8Array(Bytes.fromHex('0000')))
+      heads.push(HEAD_PLACEHOLDER)
       tails.push((value as _ARC4Encodedint8Array).uint8ArrayValue ?? asUint8Array(value.bytes))
     } else {
       if (value instanceof _Bool) {
         const before = findBool(values, i, -1, isHomogenous)
         let after = findBool(values, i, 1, isHomogenous)
-        if (before % 8 != 0) {
+        if (before % 8 !== 0) {
           throw new CodeError('"expected before index should have number of bool mod 8 equal 0"')
         }
         after = Math.min(7, after)
@@ -1195,7 +1157,7 @@ const encode = (values: (_ARC4Encoded & { uint8ArrayValue?: Uint8Array })[], isH
     tailCurrLength += tails[i].length
   }
 
-  return concatUint8Arrays(valuesLengthBytes, ...heads, ...tails)
+  return concatUint8Arrays(...heads, ...tails)
 }
 
 const isDynamicLengthType = (value: _ARC4Encoded) => {
@@ -1222,8 +1184,8 @@ export function decodeArc4<T>(
   bytes: StubBytesCompat,
   prefix: 'none' | 'log' = 'none',
 ): T {
-  const sourceTypeInfo = JSON.parse(sourceTypeInfoString)
-  const targetTypeInfo = JSON.parse(targetTypeInfoString)
+  const sourceTypeInfo = parseTypeInfo(sourceTypeInfoString)
+  const targetTypeInfo = parseTypeInfo(targetTypeInfoString)
   const encoder = getEncoder(sourceTypeInfo)
   const source = encoder(bytes, sourceTypeInfo, prefix) as { typeInfo: TypeInfo }
   return getNativeValue(source, targetTypeInfo) as T
@@ -1235,7 +1197,7 @@ export function convertBytes<T extends _ARC4Encoded>(
   bytes: StubBytesCompat,
   options: { prefix?: 'none' | 'log'; strategy: 'unsafe-cast' | 'validate' },
 ): T {
-  const typeInfo = JSON.parse(typeInfoString)
+  const typeInfo = parseTypeInfo(typeInfoString)
   return getEncoder<T>(typeInfo)(bytes, typeInfo, options.prefix)
 }
 
@@ -1316,7 +1278,7 @@ export const getArc4Encoded = (value: DeliberateAny, sourceTypeInfoString?: stri
     }
   }
   if (typeof value === 'object') {
-    const sourceTypeInfo = sourceTypeInfoString ? JSON.parse(sourceTypeInfoString) : undefined
+    const sourceTypeInfo = sourceTypeInfoString ? parseTypeInfo(sourceTypeInfoString) : undefined
     const propTypeInfos = (value.typeInfo || sourceTypeInfo || {}).genericArgs
     const result = Object.entries(value).reduce((acc: _ARC4Encoded[], [key, cur]: DeliberateAny) => {
       const propTypeInfoString = propTypeInfos?.[key] ? JSON.stringify(propTypeInfos[key]) : undefined
@@ -1379,85 +1341,87 @@ export const toUint8Array = (val: unknown, sourceTypeInfoString?: string): Uint8
   throw new InternalError(`Invalid type for bytes: ${nameOfType(val)}`)
 }
 
+const mutableTupleFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const tuple = Tuple.fromBytes(value, typeInfo, prefix)
+  return asNumber(tuple.bytes.length) ? tuple.native : ([] as unknown as typeof tuple.native)
+}
+const readonlyMutableTupleFromBytes = (
+  value: StubBytesCompat | Uint8Array,
+  typeInfo: string | TypeInfo,
+  prefix: 'none' | 'log' = 'none',
+) => {
+  const result = mutableTupleFromBytes(value, typeInfo, prefix)
+  return result as Readonly<typeof result>
+}
+const mutableObjectFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const struct = Struct.fromBytes(value, typeInfo, prefix)
+  return asNumber(struct.bytes.length) ? struct.native : ({} as unknown as typeof struct.native)
+}
+const readonlyObjectFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const result = mutableObjectFromBytes(value, typeInfo, prefix)
+  return result as Readonly<typeof result>
+}
+const arrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const dynamicArray = DynamicArray.fromBytes(value, typeInfo, prefix)
+  return asNumber(dynamicArray.bytes.length) ? dynamicArray.native : ([] as unknown as typeof dynamicArray.native)
+}
+const readonlyArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const result = arrayFromBytes(value, typeInfo, prefix)
+  return result as Readonly<typeof result>
+}
+const referenceArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const dynamicArray = DynamicArray.fromBytes(value, typeInfo, prefix)
+  return new ReferenceArray(
+    typeInfo,
+    ...(asNumber(dynamicArray.bytes.length) ? dynamicArray.native : ([] as unknown as typeof dynamicArray.native)),
+  )
+}
+const fixedArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
+  const staticArray = StaticArray.fromBytes(value, typeInfo, prefix)
+  return new FixedArray(
+    typeInfo,
+    ...(asNumber(staticArray.uint8ArrayValue.length) ? staticArray.native : ([] as unknown as typeof staticArray.native)),
+  )
+}
+
+const encodersByName: Record<string, fromBytes<DeliberateAny>> = {
+  Account: accountFromBytes,
+  Application: applicationFromBytes,
+  Asset: assetFromBytes,
+  boolean: booleanFromBytes,
+  biguint: bigUintFromBytes,
+  string: stringFromBytes,
+  uint64: uint64FromBytes,
+  OnCompleteAction: onCompletionFromBytes,
+  TransactionType: transactionTypeFromBytes,
+  Address: Address.fromBytes,
+  Bool: Bool.fromBytes,
+  Byte: Byte.fromBytes,
+  Str: Str.fromBytes,
+  DynamicBytes: DynamicBytes.fromBytes,
+  object: Struct.fromBytes,
+}
+const encodersByRegExp: [RegExp, fromBytes<DeliberateAny>][] = Object.entries({
+  'bytes(<.*>)?': bytesFromBytes,
+  'Uint<.*>': Uint.fromBytes,
+  'UFixed<.*>': UFixed.fromBytes,
+  'StaticArray<.*>': StaticArray.fromBytes,
+  'DynamicArray<.*>': DynamicArray.fromBytes,
+  'Tuple(<.*>)?': Tuple.fromBytes,
+  'ReadonlyTuple(<.*>)?': readonlyMutableTupleFromBytes,
+  'MutableTuple(<.*>)?': mutableTupleFromBytes,
+  'Struct(<.*>)?': Struct.fromBytes,
+  'StaticBytes<.*>': StaticBytes.fromBytes,
+  'Object<.*>': mutableObjectFromBytes,
+  'ReadonlyObject<.*>': readonlyObjectFromBytes,
+  'ReferenceArray<.*>': referenceArrayFromBytes,
+  'FixedArray<.*>': fixedArrayFromBytes,
+  'Array<.*>': arrayFromBytes,
+  'ReadonlyArray<.*>': readonlyArrayFromBytes,
+}).map(([k, v]) => [new RegExp(`^${k}$`), v] as [RegExp, fromBytes<DeliberateAny>])
 /** @internal */
 export const getEncoder = <T>(typeInfo: TypeInfo): fromBytes<T> => {
-  const mutableTupleFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const tuple = Tuple.fromBytes(value, typeInfo, prefix)
-    return asNumber(tuple.bytes.length) ? tuple.native : ([] as unknown as typeof tuple.native)
-  }
-  const readonlyMutableTupleFromBytes = (
-    value: StubBytesCompat | Uint8Array,
-    typeInfo: string | TypeInfo,
-    prefix: 'none' | 'log' = 'none',
-  ) => {
-    const result = mutableTupleFromBytes(value, typeInfo, prefix)
-    return result as Readonly<typeof result>
-  }
-  const mutableObjectFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const struct = Struct.fromBytes(value, typeInfo, prefix)
-    return asNumber(struct.bytes.length) ? struct.native : ({} as unknown as typeof struct.native)
-  }
-  const readonlyObjectFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const result = mutableObjectFromBytes(value, typeInfo, prefix)
-    return result as Readonly<typeof result>
-  }
-  const arrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const dynamicArray = DynamicArray.fromBytes(value, typeInfo, prefix)
-    return asNumber(dynamicArray.bytes.length) ? dynamicArray.native : ([] as unknown as typeof dynamicArray.native)
-  }
-  const readonlyArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const result = arrayFromBytes(value, typeInfo, prefix)
-    return result as Readonly<typeof result>
-  }
-  const referenceArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const dynamicArray = DynamicArray.fromBytes(value, typeInfo, prefix)
-    return new ReferenceArray(
-      typeInfo,
-      ...(asNumber(dynamicArray.bytes.length) ? dynamicArray.native : ([] as unknown as typeof dynamicArray.native)),
-    )
-  }
-  const fixedArrayFromBytes = (value: StubBytesCompat | Uint8Array, typeInfo: string | TypeInfo, prefix: 'none' | 'log' = 'none') => {
-    const staticArray = StaticArray.fromBytes(value, typeInfo, prefix)
-    return new FixedArray(
-      typeInfo,
-      ...(asNumber(staticArray.uint8ArrayValue.length) ? staticArray.native : ([] as unknown as typeof staticArray.native)),
-    )
-  }
-  const encoders: Record<string, fromBytes<DeliberateAny>> = {
-    account: (value) => AccountCls.fromBytes(value),
-    application: (value) => ApplicationCls.fromBytes(value),
-    asset: (value) => AssetCls.fromBytes(value),
-    boolean: booleanFromBytes,
-    biguint: bigUintFromBytes,
-    'bytes(<.*>)?': bytesFromBytes,
-    string: stringFromBytes,
-    uint64: uint64FromBytes,
-    OnCompleteAction: onCompletionFromBytes,
-    TransactionType: transactionTypeFromBytes,
-    Address: Address.fromBytes,
-    Bool: Bool.fromBytes,
-    Byte: Byte.fromBytes,
-    Str: Str.fromBytes,
-    'Uint<.*>': Uint.fromBytes,
-    'UFixed<.*>': UFixed.fromBytes,
-    'StaticArray<.*>': StaticArray.fromBytes,
-    'DynamicArray<.*>': DynamicArray.fromBytes,
-    'Tuple(<.*>)?': Tuple.fromBytes,
-    'ReadonlyTuple(<.*>)?': readonlyMutableTupleFromBytes,
-    'MutableTuple(<.*>)?': mutableTupleFromBytes,
-    'Struct(<.*>)?': Struct.fromBytes,
-    DynamicBytes: DynamicBytes.fromBytes,
-    'StaticBytes<.*>': StaticBytes.fromBytes,
-    object: Struct.fromBytes,
-    'Object<.*>': mutableObjectFromBytes,
-    'ReadonlyObject<.*>': readonlyObjectFromBytes,
-    'ReferenceArray<.*>': referenceArrayFromBytes,
-    'FixedArray<.*>': fixedArrayFromBytes,
-    'Array<.*>': arrayFromBytes,
-    'ReadonlyArray<.*>': readonlyArrayFromBytes,
-  }
-
-  const encoder = Object.entries(encoders).find(([k, _]) => new RegExp(`^${k}$`, 'i').test(typeInfo.name))?.[1]
+  const encoder = encodersByName[typeInfo.name] || encodersByRegExp.find(([k, _]) => k.test(typeInfo.name))?.[1]
   if (!encoder) {
     throw new Error(`No encoder found for type ${typeInfo.name}`)
   }

--- a/src/impl/encoded-types/helpers.ts
+++ b/src/impl/encoded-types/helpers.ts
@@ -153,7 +153,7 @@ export const holdsDynamicLengthContent = (value: TypeInfo): boolean => {
     itemTypeName === 'DynamicArray' ||
     itemTypeName === 'ReferenceArray' ||
     itemTypeName === 'DynamicBytes' ||
-    (itemTypeName === 'bytes' && itemTypeName === value.name) || // `bytes` has dynamic length but `bytes<N>` is statically sized
+    value.name === 'bytes' || // `bytes` has dynamic length but `bytes<N>` is statically sized
     itemTypeName === 'string' ||
     ((itemTypeName === 'StaticArray' || itemTypeName === 'FixedArray') &&
       holdsDynamicLengthContent((value.genericArgs as StaticArrayGenericArgs).elementType)) ||

--- a/src/impl/encoded-types/helpers.ts
+++ b/src/impl/encoded-types/helpers.ts
@@ -1,18 +1,24 @@
-import type { biguint, bytes, OnCompleteAction, TransactionType, uint64 } from '@algorandfoundation/algorand-typescript'
+import type {
+  Account,
+  Application,
+  Asset,
+  biguint,
+  bytes,
+  OnCompleteAction,
+  TransactionType,
+  uint64,
+} from '@algorandfoundation/algorand-typescript'
 import { ARC4Encoded, Bool } from '@algorandfoundation/algorand-typescript/arc4'
 import { encodingUtil } from '@algorandfoundation/puya-ts'
-import { BITS_IN_BYTE } from '../../constants'
+import { ABI_RETURN_VALUE_LOG_PREFIX, BITS_IN_BYTE } from '../../constants'
 import type { DeliberateAny } from '../../typescript-helpers'
-import { asBytesCls, assert } from '../../util'
+import { asBytes, asBytesCls, assert, asUint8Array } from '../../util'
 import { BytesBackedCls, Uint64BackedCls } from '../base'
-import type { BytesCls } from '../primitives'
-import { AlgoTsPrimitiveCls } from '../primitives'
+import type { BytesCls, StubBytesCompat } from '../primitives'
+import { AlgoTsPrimitiveCls, BigUint, Uint64 } from '../primitives'
+import { AccountCls, ApplicationCls, AssetCls } from '../reference'
 import { ABI_LENGTH_SIZE } from './constants'
-import type { StaticArrayGenericArgs, TypeInfo } from './types'
-
-import { asBytes, asUint8Array } from '../../util'
-import { BigUint, Uint64 } from '../primitives'
-import type { fromBytes } from './types'
+import type { fromBytes, StaticArrayGenericArgs, TypeInfo } from './types'
 
 /** @internal */
 export const validBitSizes = [...Array(64).keys()].map((x) => (x + 1) * 8)
@@ -29,27 +35,27 @@ export const trimTrailingDecimalZeros = (v: string) => v.replace(/(\d+\.\d*?)0+$
 export const trimGenericTypeName = (typeName: string): string => typeName.replace(/<.*>/, '')
 
 /** @internal */
-export const areAllARC4Encoded = <T extends ARC4Encoded>(items: T[]): items is T[] => items.every((item) => item instanceof ARC4Encoded)
+export const areAllARC4Encoded = <T>(items: T[]): items is T[] => items.every((item) => item instanceof ARC4Encoded)
 
 /** @internal */
 export const checkItemTypeName = (type: TypeInfo, value: ARC4Encoded) => {
-  const typeName = trimGenericTypeName(type.name)
-  const validTypeNames = [typeName]
-  assert(validTypeNames.includes(value.constructor.name), `item must be of type ${typeName}, not ${value.constructor.name}`)
+  const validTypeName = trimGenericTypeName(type.name)
+  assert(validTypeName === value.constructor.name, `item must be of type ${validTypeName}, not ${value.constructor.name}`)
 }
 
-/** @internal */
-export const findBoolTypes = (values: TypeInfo[], index: number, delta: number, isHomogenous?: boolean): number => {
-  // Helper function to find consecutive booleans from current index in a tuple.
-  let until = 0
+// Walk consecutive booleans from `index` in direction `delta`, returning the count of
+// neighbouring bools (excluding the starting element). Returns -1 if the starting element
+// is not a bool, and 0 when `index` is already at the boundary in the chosen direction.
+const findBoolRun = <T>(values: T[], index: number, delta: number, isBool: (v: T) => boolean, isHomogenous?: boolean): number => {
   const length = values.length
   if (isHomogenous) {
     return delta < 0 ? 0 : length - index - 1
   }
+  let until = 0
   while (true) {
     const curr = index + delta * until
-    if (['Bool', 'boolean'].includes(values[curr].name)) {
-      if ((curr != length - 1 && delta > 0) || (curr > 0 && delta < 0)) {
+    if (isBool(values[curr])) {
+      if ((curr !== length - 1 && delta > 0) || (curr > 0 && delta < 0)) {
         until += 1
       } else {
         break
@@ -61,6 +67,10 @@ export const findBoolTypes = (values: TypeInfo[], index: number, delta: number, 
   }
   return until
 }
+
+/** @internal */
+export const findBoolTypes = (values: TypeInfo[], index: number, delta: number, isHomogenous?: boolean): number =>
+  findBoolRun(values, index, delta, (v) => v.name === 'Bool' || v.name === 'boolean', isHomogenous)
 
 /** @internal */
 export const getNativeValue = (value: DeliberateAny, targetTypeInfo: TypeInfo | undefined): DeliberateAny => {
@@ -105,27 +115,8 @@ export const encodeLength = (length: number): BytesCls => {
 }
 
 /** @internal */
-export const findBool = (values: ARC4Encoded[], index: number, delta: number, isHomogenous?: boolean) => {
-  let until = 0
-  const length = values.length
-  if (isHomogenous) {
-    return delta < 0 ? 0 : length - index - 1
-  }
-  while (true) {
-    const curr = index + delta * until
-    if (values[curr] instanceof Bool) {
-      if ((curr !== length - 1 && delta > 0) || (curr > 0 && delta < 0)) {
-        until += 1
-      } else {
-        break
-      }
-    } else {
-      until -= 1
-      break
-    }
-  }
-  return until
-}
+export const findBool = (values: ARC4Encoded[], index: number, delta: number, isHomogenous?: boolean): number =>
+  findBoolRun(values, index, delta, (v) => v instanceof Bool, isHomogenous)
 
 /** @internal */
 export const compressMultipleBool = (values: Bool[]): number => {
@@ -168,36 +159,45 @@ export const holdsDynamicLengthContent = (value: TypeInfo): boolean => {
 }
 
 /** @internal */
-export const booleanFromBytes: fromBytes<boolean> = (val) => {
-  return encodingUtil.uint8ArrayToBigInt(asUint8Array(val)) > 0n
+export const stripLogPrefix = (value: StubBytesCompat | Uint8Array, prefix: 'none' | 'log'): Uint8Array => {
+  const uint8ArrayValue = value instanceof Uint8Array ? value : asUint8Array(value)
+  if (prefix === 'log') {
+    assert(asBytes(uint8ArrayValue.slice(0, 4)).equals(ABI_RETURN_VALUE_LOG_PREFIX), 'ABI return prefix not found')
+    return uint8ArrayValue.slice(4)
+  }
+  return uint8ArrayValue
 }
 
-/** @internal */
-export const bigUintFromBytes: fromBytes<biguint> = (val) => {
-  return BigUint(encodingUtil.uint8ArrayToBigInt(asUint8Array(val)))
-}
+const bigIntFromBytes = (val: StubBytesCompat | Uint8Array, _typeInfo: TypeInfo, prefix: 'none' | 'log' = 'none'): bigint =>
+  encodingUtil.uint8ArrayToBigInt(asUint8Array(stripLogPrefix(val, prefix)))
 
 /** @internal */
-export const bytesFromBytes: fromBytes<bytes> = (val) => {
-  return asBytes(val)
-}
+export const booleanFromBytes: fromBytes<boolean> = (...args) => bigIntFromBytes(...args) > 0n
 
 /** @internal */
-export const stringFromBytes: fromBytes<string> = (val) => {
-  return asBytes(val).toString()
-}
+export const bigUintFromBytes: fromBytes<biguint> = (...args) => BigUint(bigIntFromBytes(...args))
 
 /** @internal */
-export const uint64FromBytes: fromBytes<uint64> = (val) => {
-  return Uint64(encodingUtil.uint8ArrayToBigInt(asUint8Array(val)))
-}
+export const uint64FromBytes: fromBytes<uint64> = (...args) => Uint64(bigIntFromBytes(...args))
 
 /** @internal */
-export const onCompletionFromBytes: fromBytes<OnCompleteAction> = (val) => {
-  return Uint64(encodingUtil.uint8ArrayToBigInt(asUint8Array(val))) as OnCompleteAction
-}
+export const onCompletionFromBytes: fromBytes<OnCompleteAction> = (...args) => uint64FromBytes(...args) as OnCompleteAction
 
 /** @internal */
-export const transactionTypeFromBytes: fromBytes<TransactionType> = (val) => {
-  return Uint64(encodingUtil.uint8ArrayToBigInt(asUint8Array(val))) as TransactionType
-}
+export const transactionTypeFromBytes: fromBytes<TransactionType> = (...args) => uint64FromBytes(...args) as TransactionType
+
+/** @internal */
+export const bytesFromBytes: fromBytes<bytes> = (val, _typeInfo, prefix = 'none') => asBytes(stripLogPrefix(val, prefix))
+
+/** @internal */
+export const stringFromBytes: fromBytes<string> = (...args) => bytesFromBytes(...args).toString()
+
+/** @internal */
+export const accountFromBytes: fromBytes<Account> = (val, _typeInfo, prefix = 'none') => AccountCls.fromBytes(stripLogPrefix(val, prefix))
+
+/** @internal */
+export const applicationFromBytes: fromBytes<Application> = (val, _typeInfo, prefix = 'none') =>
+  ApplicationCls.fromBytes(stripLogPrefix(val, prefix))
+
+/** @internal */
+export const assetFromBytes: fromBytes<Asset> = (val, _typeInfo, prefix = 'none') => AssetCls.fromBytes(stripLogPrefix(val, prefix))

--- a/src/impl/itxn.ts
+++ b/src/impl/itxn.ts
@@ -872,7 +872,7 @@ export const ITxnCreate: typeof op.ITxnCreate = {
     setConstructingItxnField({ rejectVersion: asUint64(a) })
   },
   next: function (): void {
-    lazyContext.activeGroup.appendInnerTransactionGroup()
+    lazyContext.activeGroup.appendInnerTransaction()
   },
   submit: function (): void {
     lazyContext.activeGroup.submitInnerTransactionGroup()

--- a/src/impl/primitives.ts
+++ b/src/impl/primitives.ts
@@ -210,18 +210,10 @@ Bytes.fromBase32 = <TLength extends uint64 = uint64>(b32: string, options?: ToFi
 function isOptionsOnly<TLength extends uint64>(
   value?: BytesCompat | TemplateStringsArray | biguint | uint64 | Iterable<number> | ToFixedBytesOptions<TLength>,
 ): value is ToFixedBytesOptions<TLength> {
+  const keys = Object.keys(value ?? {})
   return (
-    value !== null &&
     typeof value === 'object' &&
-    !Array.isArray(value) &&
-    !isTemplateStringsArray(value) &&
-    !(Symbol.iterator in value) &&
-    !(value instanceof BigUintCls) &&
-    !(value instanceof Uint64Cls) &&
-    !(value instanceof BytesCls) &&
-    !(value instanceof Uint8Array) &&
-    Object.keys(value).length <= 2 &&
-    Object.keys(value).includes('length')
+    ((keys.length === 1 && keys[0] === 'length') || (keys.length === 2 && keys.includes('length') && keys.includes('strategy')))
   )
 }
 
@@ -273,7 +265,7 @@ function isIterable(value: unknown): value is Iterable<number> {
 /**
  * Helper function to convert an iterable of numbers to BytesCls
  */
-function convertIterableToBytes(value: Iterable<number>): BytesCls {
+function convertIterableToBytes(value: Iterable<StubUint64Compat>): BytesCls {
   const valueItems = Array.from(value).map((v) => getNumber(v))
   const invalidValue = valueItems.find((v) => v < 0 || v > 255)
   if (invalidValue !== undefined) {
@@ -293,13 +285,7 @@ function extractOptionsFromReplacements<TLength extends uint64>(
   }
 
   const potentialOptions = replacements[0]
-  // Check if the replacement looks like options
-  if (
-    typeof potentialOptions === 'object' &&
-    potentialOptions !== null &&
-    Object.keys(potentialOptions).length <= 2 &&
-    Object.keys(potentialOptions).includes('length')
-  ) {
+  if (isOptionsOnly(potentialOptions)) {
     return potentialOptions as ToFixedBytesOptions<TLength>
   }
 

--- a/src/impl/primitives.ts
+++ b/src/impl/primitives.ts
@@ -114,7 +114,7 @@ export function Bytes(value: TemplateStringsArray, ...replacements: BytesCompat[
  */
 export function Bytes(value: string): bytes<uint64>
 /**
- * Create a byte array from a utf8 string
+ * Create a fixed-size byte array from a utf8 string
  */
 export function Bytes<TLength extends uint64>(value: string, options: ToFixedBytesOptions<TLength>): bytes<TLength>
 /**
@@ -130,7 +130,7 @@ export function Bytes<TLength extends uint64>(value: bytes, options: ToFixedByte
  */
 export function Bytes(value: biguint): bytes<uint64>
 /**
- * Create a byte array from a biguint value encoded as a variable length big-endian number
+ * Create a fixed-size byte array from a biguint value encoded as a variable length big-endian number
  */
 export function Bytes<TLength extends uint64>(value: biguint, options: ToFixedBytesOptions<TLength>): bytes<TLength>
 /**
@@ -138,7 +138,7 @@ export function Bytes<TLength extends uint64>(value: biguint, options: ToFixedBy
  */
 export function Bytes(value: uint64): bytes<uint64>
 /**
- * Create a byte array from a uint64 value encoded as a a variable length 64-bit number
+ * Create a fixed-size byte array from a uint64 value encoded as a a variable length 64-bit number
  */
 export function Bytes<TLength extends uint64 = 8>(value: uint64, options: ToFixedBytesOptions<TLength>): bytes<TLength>
 /**
@@ -146,7 +146,7 @@ export function Bytes<TLength extends uint64 = 8>(value: uint64, options: ToFixe
  */
 export function Bytes(value: Iterable<uint64>): bytes<uint64>
 /**
- * Create a byte array from an Iterable<uint64> where each item is interpreted as a single byte and must be between 0 and 255 inclusively
+ * Create a fixed-size byte array from an Iterable<uint64> where each item is interpreted as a single byte and must be between 0 and 255 inclusively
  */
 export function Bytes<TLength extends uint64>(value: Iterable<uint64>, options: ToFixedBytesOptions<TLength>): bytes<TLength>
 /**
@@ -154,7 +154,7 @@ export function Bytes<TLength extends uint64>(value: Iterable<uint64>, options: 
  */
 export function Bytes(): bytes<uint64>
 /**
- * Create an empty byte array
+ * Create an empty fixed-size byte array
  */
 export function Bytes<TLength extends uint64 = uint64>(options: ToFixedBytesOptions<TLength>): bytes<TLength>
 export function Bytes<TLength extends uint64 = uint64>(

--- a/src/impl/primitives.ts
+++ b/src/impl/primitives.ts
@@ -323,7 +323,7 @@ export const getNumber = (v: StubUint64Compat): number => {
     return Number(v)
   }
   if (v instanceof Uint64Cls) return v.asNumber()
-  throw new InternalError(`Cannot convert ${v} to number`)
+  throw new InternalError(`Cannot convert ${nameOfType(v)} to number`)
 }
 
 /** @internal */
@@ -417,7 +417,7 @@ export class Uint64Cls extends AlgoTsPrimitiveCls {
     if (typeof v == 'number') return new Uint64Cls(BigInt(v))
     if (typeof v == 'bigint') return new Uint64Cls(v)
     if (v instanceof Uint64Cls) return v
-    throw new InternalError(`Cannot convert ${v} to uint64`)
+    throw new InternalError(`Cannot convert ${nameOfType(v)} to uint64`)
   }
 
   valueOf(): bigint {
@@ -493,7 +493,7 @@ export class BigUintCls extends AlgoTsPrimitiveCls {
 }
 
 function isTemplateStringsArray(v: unknown): v is TemplateStringsArray {
-  return Boolean(v) && Array.isArray(v) && typeof v[0] === 'string'
+  return Array.isArray(v) && 'raw' in v
 }
 
 /** @internal */
@@ -607,7 +607,7 @@ export class BytesCls extends AlgoTsPrimitiveCls {
     return template
       .flatMap((templateText, index) => {
         const replacement = replacements[index]
-        if (replacement) {
+        if (replacement !== undefined) {
           return [BytesCls.fromCompat(templateText), BytesCls.fromCompat(replacement)]
         }
         return [BytesCls.fromCompat(templateText)]

--- a/src/impl/pure.ts
+++ b/src/impl/pure.ts
@@ -6,6 +6,8 @@ import { asBigUint, asBytes, asBytesCls, asMaybeBytesCls, asMaybeUint64Cls, asUi
 import type { StubBigUintCompat, StubBytesCompat, StubUint64Compat } from './primitives'
 import { BigUintCls, Bytes, BytesCls, checkBigUint, isUint64, Uint64, Uint64Cls } from './primitives'
 
+const BYTES_IN_UINT64 = UINT64_SIZE / BITS_IN_BYTE
+
 /** @internal */
 export const addw = (a: StubUint64Compat, b: StubUint64Compat): readonly [uint64, uint64] => {
   const uint64A = Uint64Cls.fromCompat(a)
@@ -49,7 +51,7 @@ export const bsqrt = (a: StubBigUintCompat): biguint => {
 /** @internal */
 export const btoi = (a: StubBytesCompat): uint64 => {
   const bytesValue = BytesCls.fromCompat(a)
-  if (bytesValue.length.asAlgoTs() > BITS_IN_BYTE) {
+  if (bytesValue.length.asAlgoTs() > BYTES_IN_UINT64) {
     throw new AvmError(`btoi arg too long, got ${bytesValue.length.valueOf()} bytes`)
   }
   return bytesValue.toUint64().asAlgoTs()
@@ -209,7 +211,7 @@ export const replace = (a: StubBytesCompat, b: StubUint64Compat, c: StubBytesCom
   return bytesValue
     .slice(0, index)
     .concat(replacement)
-    .concat(bytesValue.slice(index + replacementLength, valueLength))
+    .concat(bytesValue.slice(index + replacementLength))
     .asAlgoTs()
 }
 
@@ -260,14 +262,15 @@ export const setByte = (a: StubBytesCompat, b: StubUint64Compat, c: StubUint64Co
   const bitIndex = byteIndex * BITS_IN_BYTE
 
   const replacementNumber = Uint64Cls.fromCompat(c)
-  const replacement = toBinaryString(replacementNumber.toBytes().at(-1).asAlgoTs())
+  if (replacementNumber.valueOf() > MAX_UINT8) {
+    throw new CodeError(`setByte value ${replacementNumber.valueOf()} > ${MAX_UINT8}`)
+  }
 
+  const replacement = toBinaryString(replacementNumber.toBytes().at(-1).asAlgoTs())
   if (bitIndex >= binaryString.length) {
     throw new CodeError(`setByte index ${byteIndex} is beyond length`)
   }
-  if (replacementNumber.valueOf() > MAX_UINT8) {
-    throw new CodeError(`setByte value ${replacementNumber.asNumber()} > ${MAX_UINT8}`)
-  }
+
   const updatedString = binaryString.slice(0, bitIndex) + replacement + binaryString.slice(bitIndex + replacement.length)
   const updatedBytes = binaryStringToBytes(updatedString)
   return updatedBytes.asAlgoTs()
@@ -282,7 +285,7 @@ export const shl = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
   if (bigIntB >= UINT64_SIZE) {
     throw new CodeError(`shl value ${bigIntB} >= ${UINT64_SIZE}`)
   }
-  const shifted = (bigIntA * 2n ** bigIntB) % 2n ** BigInt(UINT64_SIZE)
+  const shifted = (bigIntA << bigIntB) & MAX_UINT64
   return Uint64(shifted)
 }
 
@@ -295,7 +298,7 @@ export const shr = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
   if (bigIntB >= UINT64_SIZE) {
     throw new CodeError(`shr value ${bigIntB} >= ${UINT64_SIZE}`)
   }
-  const shifted = bigIntA / 2n ** bigIntB
+  const shifted = bigIntA >> bigIntB
   return Uint64(shifted)
 }
 
@@ -356,7 +359,7 @@ const toBinaryString = (a: bytes): string => {
 
 const doSetBit = (binaryString: string, index: number, bit: number): BytesCls => {
   if (index < 0 || index >= binaryString.length) {
-    throw new CodeError(`setBit index ${index < 0 ? binaryString.length - index : index} is beyond length`)
+    throw new CodeError(`setBit index ${index < 0 ? binaryString.length - index - 1 : index} is beyond length`)
   }
   if (bit !== 0 && bit !== 1) {
     throw new CodeError(`setBit value > 1`)

--- a/src/impl/pure.ts
+++ b/src/impl/pure.ts
@@ -171,7 +171,7 @@ export const getByte = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
   const bytesValue = BytesCls.fromCompat(a)
   const index = Uint64Cls.fromCompat(b).asNumber()
   if (index >= bytesValue.length.asNumber()) {
-    throw new CodeError(`getBytes index ${index} is beyond length`)
+    throw new CodeError(`getByte index ${index} is beyond length`)
   }
   return bytesValue.at(index).toUint64().asAlgoTs()
 }

--- a/src/impl/pure.ts
+++ b/src/impl/pure.ts
@@ -2,25 +2,37 @@ import type { biguint, bytes, op, uint64 } from '@algorandfoundation/algorand-ty
 import { Base64 } from '@algorandfoundation/algorand-typescript'
 import { BITS_IN_BYTE, MAX_BYTES_SIZE, MAX_UINT64, MAX_UINT8, UINT64_SIZE } from '../constants'
 import { AvmError, CodeError, invariant, NotImplementedError } from '../errors'
-import { asBigUint, asBytes, asBytesCls, asMaybeBytesCls, asMaybeUint64Cls, asUint64Cls, binaryStringToBytes } from '../util'
-import type { StubBigUintCompat, StubBytesCompat, StubUint64Compat } from './primitives'
-import { BigUintCls, Bytes, BytesCls, checkBigUint, isUint64, Uint64, Uint64Cls } from './primitives'
+import {
+  asBigUint,
+  asBigUintCls,
+  asBytes,
+  asBytesCls,
+  asMaybeBytesCls,
+  asMaybeUint64Cls,
+  asNumber,
+  asUint64BigInt,
+  asUint64Bytes,
+  asUint64Cls,
+  asUint8Array,
+  binaryStringToBytes,
+} from '../util'
+import type { BytesCls, StubBigUintCompat, StubBytesCompat, StubUint64Compat } from './primitives'
+import { Bytes, checkBigUint, Uint64 } from './primitives'
 
 const BYTES_IN_UINT64 = UINT64_SIZE / BITS_IN_BYTE
 
 /** @internal */
 export const addw = (a: StubUint64Compat, b: StubUint64Compat): readonly [uint64, uint64] => {
-  const uint64A = Uint64Cls.fromCompat(a)
-  const uint64B = Uint64Cls.fromCompat(b)
-  const sum = uint64A.asBigInt() + uint64B.asBigInt()
+  const uint64A = asUint64BigInt(a)
+  const uint64B = asUint64BigInt(b)
+  const sum = uint64A + uint64B
   return toUint128(sum)
 }
 
 /** @internal */
 export const base64Decode = (e: Base64, a: StubBytesCompat): bytes => {
   const encoding = e === Base64.StdEncoding ? 'base64' : 'base64url'
-  const bytesValue = BytesCls.fromCompat(a)
-  const stringValue = bytesValue.toString()
+  const stringValue = asBytesCls(a).toString()
 
   const bufferResult = Buffer.from(stringValue, encoding)
   if (bufferResult.toString(encoding) !== stringValue) {
@@ -33,24 +45,27 @@ export const base64Decode = (e: Base64, a: StubBytesCompat): bytes => {
 
 /** @internal */
 export const bitLength = (a: StubUint64Compat | StubBytesCompat): uint64 => {
-  const uint64Cls = asMaybeUint64Cls(a)
-  const bigUintCls = asMaybeBytesCls(a)?.toBigUint()
-  const bigIntValue = (uint64Cls?.asBigInt() ?? bigUintCls?.asBigInt())!
-  const binaryValue = bigIntValue === 0n ? '' : bigIntValue.toString(2)
-  return Uint64(binaryValue.length)
+  const uint64BigInt = asMaybeUint64Cls(a)?.asBigInt()
+  const bytesBigInt = asMaybeBytesCls(a)?.toBigUint()?.asBigInt()
+  const bigIntValue = uint64BigInt ?? bytesBigInt
+  invariant(bigIntValue !== undefined, 'value must be uint64 or bytes')
+
+  if (bigIntValue === 0n) {
+    return 0
+  }
+  return bigIntValue.toString(2).length
 }
 
 /** @internal */
 export const bsqrt = (a: StubBigUintCompat): biguint => {
-  const bigUintClsValue = BigUintCls.fromCompat(a)
-  const bigintValue = checkBigUint(bigUintClsValue.asBigInt())
+  const bigintValue = checkBigUint(asBigUintCls(a).asBigInt())
   const sqrtValue = squareroot(bigintValue)
   return asBigUint(sqrtValue)
 }
 
 /** @internal */
 export const btoi = (a: StubBytesCompat): uint64 => {
-  const bytesValue = BytesCls.fromCompat(a)
+  const bytesValue = asBytesCls(a)
   if (bytesValue.length.asAlgoTs() > BYTES_IN_UINT64) {
     throw new AvmError(`btoi arg too long, got ${bytesValue.length.valueOf()} bytes`)
   }
@@ -59,7 +74,7 @@ export const btoi = (a: StubBytesCompat): uint64 => {
 
 /** @internal */
 export const bzero = (a: StubUint64Compat): bytes => {
-  const size = Uint64Cls.fromCompat(a).asBigInt()
+  const size = asUint64BigInt(a)
   if (size > MAX_BYTES_SIZE) {
     throw new AvmError('bzero attempted to create a too large string')
   }
@@ -68,9 +83,7 @@ export const bzero = (a: StubUint64Compat): bytes => {
 
 /** @internal */
 export const concat = (a: StubBytesCompat, b: StubBytesCompat): bytes => {
-  const bytesA = BytesCls.fromCompat(a)
-  const bytesB = BytesCls.fromCompat(b)
-  return bytesA.concat(bytesB).asAlgoTs()
+  return asBytes(a).concat(asBytes(b))
 }
 
 /** @internal */
@@ -91,14 +104,14 @@ export const divmodw = (
 /** @internal */
 export const divw = (a: StubUint64Compat, b: StubUint64Compat, c: StubUint64Compat): uint64 => {
   const i = uint128ToBigInt(a, b)
-  const j = Uint64Cls.fromCompat(c).asBigInt()
+  const j = asUint64BigInt(c)
   return Uint64(i / j)
 }
 
 /** @internal */
 export const exp = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
-  const base = Uint64Cls.fromCompat(a).asBigInt()
-  const exponent = Uint64Cls.fromCompat(b).asBigInt()
+  const base = asUint64BigInt(a)
+  const exponent = asUint64BigInt(b)
   if (base === 0n && exponent === 0n) {
     throw new CodeError('0 ** 0 is undefined')
   }
@@ -107,8 +120,8 @@ export const exp = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
 
 /** @internal */
 export const expw = (a: StubUint64Compat, b: StubUint64Compat): readonly [uint64, uint64] => {
-  const base = Uint64Cls.fromCompat(a).asBigInt()
-  const exponent = Uint64Cls.fromCompat(b).asBigInt()
+  const base = asUint64BigInt(a)
+  const exponent = asUint64BigInt(b)
   if (base === 0n && exponent === 0n) {
     throw new CodeError('0 ** 0 is undefined')
   }
@@ -119,11 +132,11 @@ type ExtractType = ((a: StubBytesCompat, b: StubUint64Compat) => bytes) &
   ((a: StubBytesCompat, b: StubUint64Compat, c: StubUint64Compat) => bytes)
 /** @internal */
 export const extract = ((a: StubBytesCompat, b: StubUint64Compat, c?: StubUint64Compat): bytes => {
-  const bytesValue = BytesCls.fromCompat(a)
+  const bytesValue = asBytesCls(a)
   const bytesLength = bytesValue.length.asBigInt()
 
-  const start = Uint64Cls.fromCompat(b).asBigInt()
-  const length = c !== undefined ? Uint64Cls.fromCompat(c).asBigInt() : undefined
+  const start = asUint64BigInt(b)
+  const length = c !== undefined ? asUint64BigInt(c) : undefined
   const end = length !== undefined ? start + length : undefined
 
   if (start > bytesLength) {
@@ -139,29 +152,35 @@ export const extract = ((a: StubBytesCompat, b: StubUint64Compat, c?: StubUint64
 /** @internal */
 export const extractUint16 = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
   const result = extract(a, b, 2)
-  const bytesResult = BytesCls.fromCompat(result)
+  const bytesResult = asBytesCls(result)
   return bytesResult.toUint64().asAlgoTs()
 }
 
 /** @internal */
 export const extractUint32 = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
   const result = extract(a, b, 4)
-  const bytesResult = BytesCls.fromCompat(result)
+  const bytesResult = asBytesCls(result)
   return bytesResult.toUint64().asAlgoTs()
 }
 
 /** @internal */
 export const extractUint64 = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
   const result = extract(a, b, 8)
-  const bytesResult = BytesCls.fromCompat(result)
+  const bytesResult = asBytesCls(result)
   return bytesResult.toUint64().asAlgoTs()
 }
 
 /** @internal */
 export const getBit = (a: StubUint64Compat | StubBytesCompat, b: StubUint64Compat): boolean => {
-  const binaryString = toBinaryString(isUint64(a) ? asUint64Cls(a).toBytes().asAlgoTs() : asBytes(a))
-  const index = Uint64Cls.fromCompat(b).asNumber()
-  const adjustedIndex = asMaybeUint64Cls(a) ? binaryString.length - index - 1 : index
+  const aAsUint64 = asMaybeUint64Cls(a)
+  const aAsBytes = asMaybeBytesCls(a)
+
+  const source = aAsUint64 ?? aAsBytes
+  invariant(source, 'a must be uint64 or bytes')
+  const binaryString = toBinaryString(source.toBytes())
+
+  const index = asNumber(b)
+  const adjustedIndex = aAsUint64 ? binaryString.length - index - 1 : index
   if (adjustedIndex < 0 || adjustedIndex >= binaryString.length) {
     throw new CodeError(`getBit index ${index} is beyond length`)
   }
@@ -170,8 +189,8 @@ export const getBit = (a: StubUint64Compat | StubBytesCompat, b: StubUint64Compa
 
 /** @internal */
 export const getByte = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
-  const bytesValue = BytesCls.fromCompat(a)
-  const index = Uint64Cls.fromCompat(b).asNumber()
+  const bytesValue = asBytesCls(a)
+  const index = asNumber(b)
   if (index >= bytesValue.length.asNumber()) {
     throw new CodeError(`getByte index ${index} is beyond length`)
   }
@@ -180,7 +199,7 @@ export const getByte = (a: StubBytesCompat, b: StubUint64Compat): uint64 => {
 
 /** @internal */
 export const itob = (a: StubUint64Compat): bytes => {
-  return asUint64Cls(a).toBytes().asAlgoTs()
+  return asUint64Bytes(a).asAlgoTs()
 }
 
 /** @internal */
@@ -190,17 +209,15 @@ export const len = (a: StubBytesCompat): uint64 => {
 
 /** @internal */
 export const mulw = (a: StubUint64Compat, b: StubUint64Compat): readonly [uint64, uint64] => {
-  const uint64A = Uint64Cls.fromCompat(a)
-  const uint64B = Uint64Cls.fromCompat(b)
-  const product = uint64A.asBigInt() * uint64B.asBigInt()
+  const product = asUint64BigInt(a) * asUint64BigInt(b)
   return toUint128(product)
 }
 
 /** @internal */
 export const replace = (a: StubBytesCompat, b: StubUint64Compat, c: StubBytesCompat): bytes => {
-  const bytesValue = BytesCls.fromCompat(a)
-  const index = Uint64Cls.fromCompat(b).asNumber()
-  const replacement = BytesCls.fromCompat(c)
+  const bytesValue = asBytesCls(a)
+  const index = asNumber(b)
+  const replacement = asBytesCls(c)
 
   const valueLength = bytesValue.length.asNumber()
   const replacementLength = replacement.length.asNumber()
@@ -215,7 +232,7 @@ export const replace = (a: StubBytesCompat, b: StubUint64Compat, c: StubBytesCom
     .asAlgoTs()
 }
 
-type selectType = ((a: StubBytesCompat, b: StubBytesCompat, c: StubUint64Compat) => bytes) &
+type SelectType = ((a: StubBytesCompat, b: StubBytesCompat, c: StubUint64Compat) => bytes) &
   ((a: StubUint64Compat, b: StubUint64Compat, c: StubUint64Compat) => uint64)
 /** @internal */
 export const select = ((
@@ -223,32 +240,30 @@ export const select = ((
   b: StubUint64Compat | StubBytesCompat,
   c: StubUint64Compat,
 ): uint64 | bytes => {
-  const uint64A = asMaybeUint64Cls(a)
-  const uint64B = asMaybeUint64Cls(b)
-  const bytesA = asMaybeBytesCls(a)
-  const bytesB = asMaybeBytesCls(b)
-  const bigIntC = Uint64Cls.fromCompat(c).asBigInt()
+  const choiceA = asMaybeUint64Cls(a) ?? asMaybeBytesCls(a)
+  const choiceB = asMaybeUint64Cls(b) ?? asMaybeBytesCls(b)
+  invariant(choiceA, 'a must be uint64 or bytes')
+  invariant(choiceB, 'b must be uint64 or bytes')
 
-  return (bigIntC !== 0n ? (uint64B ?? bytesB)! : (uint64A ?? bytesA)!).asAlgoTs()
-}) as selectType
+  return (asUint64BigInt(c) !== 0n ? choiceB : choiceA).asAlgoTs()
+}) as SelectType
 
 type SetBitType = ((target: StubBytesCompat, n: StubUint64Compat, c: StubUint64Compat) => bytes) &
   ((target: StubUint64Compat, n: StubUint64Compat, c: StubUint64Compat) => uint64)
-
 /** @internal */
 export const setBit = ((a: StubUint64Compat | StubBytesCompat, b: StubUint64Compat, c: StubUint64Compat) => {
   const uint64Cls = asMaybeUint64Cls(a)
-  const indexParam = Uint64Cls.fromCompat(b).asNumber()
-  const bit = Uint64Cls.fromCompat(c).asNumber()
+  const indexParam = asNumber(b)
+  const bit = asNumber(c)
   if (uint64Cls) {
-    const binaryString = toBinaryString(uint64Cls?.toBytes().asAlgoTs())
+    const binaryString = toBinaryString(uint64Cls.toBytes())
     const index = binaryString.length - indexParam - 1
     const newBytes = doSetBit(binaryString, index, bit)
     return newBytes.toUint64().asAlgoTs()
   } else {
     const bytesCls = asMaybeBytesCls(a)
     invariant(bytesCls, 'a must be uint64 or bytes')
-    const binaryString = toBinaryString(bytesCls.asAlgoTs())
+    const binaryString = toBinaryString(bytesCls)
     const newBytes = doSetBit(binaryString, indexParam, bit)
     return newBytes.asAlgoTs()
   }
@@ -256,17 +271,17 @@ export const setBit = ((a: StubUint64Compat | StubBytesCompat, b: StubUint64Comp
 
 /** @internal */
 export const setByte = (a: StubBytesCompat, b: StubUint64Compat, c: StubUint64Compat): bytes => {
-  const binaryString = toBinaryString(BytesCls.fromCompat(a).asAlgoTs())
+  const binaryString = toBinaryString(a)
 
-  const byteIndex = Uint64Cls.fromCompat(b).asNumber()
+  const byteIndex = asNumber(b)
   const bitIndex = byteIndex * BITS_IN_BYTE
 
-  const replacementNumber = Uint64Cls.fromCompat(c)
+  const replacementNumber = asUint64Cls(c)
   if (replacementNumber.valueOf() > MAX_UINT8) {
     throw new CodeError(`setByte value ${replacementNumber.valueOf()} > ${MAX_UINT8}`)
   }
 
-  const replacement = toBinaryString(replacementNumber.toBytes().at(-1).asAlgoTs())
+  const replacement = toBinaryString(replacementNumber.toBytes().at(-1))
   if (bitIndex >= binaryString.length) {
     throw new CodeError(`setByte index ${byteIndex} is beyond length`)
   }
@@ -278,10 +293,8 @@ export const setByte = (a: StubBytesCompat, b: StubUint64Compat, c: StubUint64Co
 
 /** @internal */
 export const shl = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
-  const uint64A = Uint64Cls.fromCompat(a)
-  const uint64B = Uint64Cls.fromCompat(b)
-  const bigIntA = uint64A.asBigInt()
-  const bigIntB = uint64B.asBigInt()
+  const bigIntA = asUint64BigInt(a)
+  const bigIntB = asUint64BigInt(b)
   if (bigIntB >= UINT64_SIZE) {
     throw new CodeError(`shl value ${bigIntB} >= ${UINT64_SIZE}`)
   }
@@ -291,10 +304,8 @@ export const shl = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
 
 /** @internal */
 export const shr = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
-  const uint64A = Uint64Cls.fromCompat(a)
-  const uint64B = Uint64Cls.fromCompat(b)
-  const bigIntA = uint64A.asBigInt()
-  const bigIntB = uint64B.asBigInt()
+  const bigIntA = asUint64BigInt(a)
+  const bigIntB = asUint64BigInt(b)
   if (bigIntB >= UINT64_SIZE) {
     throw new CodeError(`shr value ${bigIntB} >= ${UINT64_SIZE}`)
   }
@@ -304,16 +315,16 @@ export const shr = (a: StubUint64Compat, b: StubUint64Compat): uint64 => {
 
 /** @internal */
 export const sqrt = (a: StubUint64Compat): uint64 => {
-  const bigIntValue = Uint64Cls.fromCompat(a).asBigInt()
+  const bigIntValue = asUint64BigInt(a)
   const sqrtValue = squareroot(bigIntValue)
   return Uint64(sqrtValue)
 }
 
 /** @internal */
 export const substring = (a: StubBytesCompat, b: StubUint64Compat, c: StubUint64Compat): bytes => {
-  const bytesValue = BytesCls.fromCompat(a)
-  const start = Uint64Cls.fromCompat(b).asBigInt()
-  const end = Uint64Cls.fromCompat(c).asBigInt()
+  const bytesValue = asBytesCls(a)
+  const start = asUint64BigInt(b)
+  const end = asUint64BigInt(c)
   if (start > end) {
     throw new CodeError('substring end before start')
   }
@@ -348,13 +359,13 @@ const toUint128 = (value: bigint): [uint64, uint64] => {
 }
 
 const uint128ToBigInt = (a: StubUint64Compat, b: StubUint64Compat): bigint => {
-  const bigIntA = Uint64Cls.fromCompat(a).asBigInt()
-  const bigIntB = Uint64Cls.fromCompat(b).asBigInt()
+  const bigIntA = asUint64BigInt(a)
+  const bigIntB = asUint64BigInt(b)
   return (bigIntA << 64n) + bigIntB
 }
 
-const toBinaryString = (a: bytes): string => {
-  return [...BytesCls.fromCompat(a).asUint8Array()].map((x) => x.toString(2).padStart(BITS_IN_BYTE, '0')).join('')
+const toBinaryString = (a: StubBytesCompat): string => {
+  return [...asUint8Array(a)].map((x) => x.toString(2).padStart(BITS_IN_BYTE, '0')).join('')
 }
 
 const doSetBit = (binaryString: string, index: number, bit: number): BytesCls => {

--- a/src/impl/reference.ts
+++ b/src/impl/reference.ts
@@ -22,7 +22,7 @@ import {
 import { lazyContext } from '../context-helpers/internal-context'
 import { AvmError, InternalError } from '../errors'
 import type { DeliberateAny, Mutable } from '../typescript-helpers'
-import { asBigInt, asBytes, asUint64, asUint64Cls, asUint8Array, concatUint8Arrays } from '../util'
+import { asBytes, asUint64, asUint64BigInt, asUint64Cls, asUint8Array, concatUint8Arrays } from '../util'
 import { BytesBackedCls, Uint64BackedCls } from './base'
 import type { StubUint64Compat } from './primitives'
 import { Bytes, BytesCls, Uint64Cls } from './primitives'
@@ -322,7 +322,7 @@ export const checksumFromPublicKey = (pk: Uint8Array): Uint8Array => {
 
 /** @internal */
 export const getApplicationAddress = (appId: StubUint64Compat): AccountType => {
-  const toBeSigned = concatUint8Arrays(asUint8Array(APP_ID_PREFIX), encodingUtil.bigIntToUint8Array(asBigInt(appId), 8))
+  const toBeSigned = concatUint8Arrays(asUint8Array(APP_ID_PREFIX), encodingUtil.bigIntToUint8Array(asUint64BigInt(appId), 8))
   const appIdHash = js_sha512.sha512_256.array(toBeSigned)
   const publicKey = Uint8Array.from(appIdHash)
   const address = encodeAddress(publicKey)

--- a/src/impl/urange.ts
+++ b/src/impl/urange.ts
@@ -1,11 +1,11 @@
-import { asBigInt, asUint64 } from '../util'
+import { asUint64, asUint64BigInt } from '../util'
 import type { StubUint64Compat } from './primitives'
 
 /** @internal */
 export function* urange(a: StubUint64Compat, b?: StubUint64Compat, c?: StubUint64Compat) {
-  const start = b ? asBigInt(a) : BigInt(0)
-  const end = b ? asBigInt(b) : asBigInt(a)
-  const step = c ? asBigInt(c) : BigInt(1)
+  const start = b ? asUint64BigInt(a) : BigInt(0)
+  const end = b ? asUint64BigInt(b) : asUint64BigInt(a)
+  const step = c ? asUint64BigInt(c) : BigInt(1)
   let iterationCount = 0
   for (let i = start; i < end; i += step) {
     iterationCount++

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -36,7 +36,7 @@ interface States {
 
 const isUint64GenericType = (typeInfo: TypeInfo | undefined) => {
   if (!Array.isArray(typeInfo?.genericArgs) || !typeInfo?.genericArgs?.length) return false
-  return typeInfo.genericArgs.some((t) => t.name.toLocaleLowerCase() === 'uint64')
+  return typeInfo.genericArgs.some((t) => t.name.toLowerCase() === 'uint64')
 }
 
 const extractStates = (contract: BaseContract, contractOptions: ContractOptionsParameter | undefined): States => {
@@ -222,8 +222,8 @@ export class ContractContext {
    * @internal
    */
   private getContractProxyHandler<T extends BaseContract>(isArc4: boolean): ProxyHandler<IConstructor<T>> {
-    const onConstructed = (application: Application, instance: T, conrtactOptions: ContractOptionsParameter | undefined) => {
-      const states = extractStates(instance, conrtactOptions)
+    const onConstructed = (application: Application, instance: T, contractOptions: ContractOptionsParameter | undefined) => {
+      const states = extractStates(instance, contractOptions)
 
       const applicationData = lazyContext.ledger.applicationDataMap.getOrFail(application.id)
       applicationData.application = {

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -6,7 +6,7 @@ import { getArc4Selector, getContractAbiMetadata, getContractMethodAbiMetadata }
 import { BytesMap } from '../collections/custom-key-map'
 import { checkRoutingConditions } from '../context-helpers/context-util'
 import { lazyContext } from '../context-helpers/internal-context'
-import { CodeError } from '../errors'
+import { CodeError, invariant } from '../errors'
 import type { BaseContract } from '../impl/base-contract'
 import { ContractOptionsSymbol } from '../impl/base-contract'
 import type { Contract } from '../impl/contract'
@@ -64,7 +64,7 @@ const extractStates = (contract: BaseContract, contractOptions: ContractOptionsP
 
     if (isLocalState || isGlobalState) {
       // populate state totals
-      const isUint64State = isUint64GenericType(getGenericTypeInfo(value)!)
+      const isUint64State = isUint64GenericType(getGenericTypeInfo(value))
       stateTotals.globalNumUint += isGlobalState && isUint64State ? 1 : 0
       stateTotals.globalNumBytes += isGlobalState && !isUint64State ? 1 : 0
       stateTotals.localNumUint += isLocalState && isUint64State ? 1 : 0
@@ -103,21 +103,21 @@ export const extractArraysFromArgs = (
     } else if (arg instanceof AccountCls) {
       if (resourceEncoding === 'index') {
         appArgs.push(getUint8(accounts.length))
-        accounts.push(arg as Account)
+        accounts.push(arg)
       } else {
         appArgs.push(getArc4Encoded(arg.bytes))
       }
     } else if (arg instanceof ApplicationCls) {
       if (resourceEncoding === 'index') {
         appArgs.push(getUint8(apps.length))
-        apps.push(arg as Application)
+        apps.push(arg)
       } else {
         appArgs.push(getArc4Encoded(arg.id))
       }
     } else if (arg instanceof AssetCls) {
       if (resourceEncoding === 'index') {
         appArgs.push(getUint8(assets.length))
-        assets.push(arg as Asset)
+        assets.push(arg)
       } else {
         appArgs.push(getArc4Encoded(arg.id))
       }
@@ -135,7 +135,7 @@ export const extractArraysFromArgs = (
     apps,
     assets,
     transactions,
-    appArgs: [Bytes(methodSelector), ...appArgs.filter((a) => a !== undefined).map((a) => a.bytes)],
+    appArgs: [Bytes(methodSelector), ...appArgs.map((a) => a.bytes)],
   }
 }
 
@@ -202,7 +202,7 @@ export class ContractContext {
       // TODO: This needs to be specifiable by the test code
       onCompletion: OnCompleteAction[(abiMetadata?.allowActions ?? [])[0]],
     })
-    const txns = [...(transactions ?? []), appTxn]
+    const txns = [...transactions, appTxn]
     return txns
   }
 
@@ -210,7 +210,7 @@ export class ContractContext {
    * @internal
    */
   private isArc4<T extends BaseContract>(type: IConstructor<T>): boolean {
-    const result = (type as DeliberateAny as typeof BaseContract).isArc4
+    const result = (type as unknown as typeof BaseContract).isArc4
     if (result !== undefined && result !== null) {
       return result
     }
@@ -245,14 +245,15 @@ export class ContractContext {
         lazyContext.txn.ensureScope([txn]).execute(() => {
           t = new target(...args)
         })
-        appData.isCreating = isArc4 && hasCreateMethods(t! as Contract)
-        const instance = new Proxy(t!, {
-          get(target, prop, receiver) {
+        invariant(t, 'Contract construction failed to produce an instance')
+        appData.isCreating = isArc4 && hasCreateMethods(t as Contract)
+        const instance = new Proxy(t, {
+          get(target: T, prop, receiver) {
             const orig = Reflect.get(target, prop, receiver)
             const abiMetadata =
               isArc4 && typeof orig === 'function' ? getContractMethodAbiMetadata(target as Contract, orig.name) : undefined
             const isProgramMethod = prop === 'approvalProgram' || prop === 'clearStateProgram'
-            const isAbiMethod = isArc4 && abiMetadata
+            const isAbiMethod = isArc4 && !!abiMetadata
             if (isAbiMethod || isProgramMethod) {
               return (...args: DeliberateAny[]): DeliberateAny => {
                 const txns = ContractContext.createMethodCallTxns(receiver, abiMetadata, ...args)
@@ -261,7 +262,7 @@ export class ContractContext {
                     checkRoutingConditions(application.id, abiMetadata)
                   }
                   const returnValue = (orig as DeliberateAny).apply(target, args)
-                  if (!isProgramMethod && isAbiMethod && returnValue !== undefined) {
+                  if (isAbiMethod && returnValue !== undefined) {
                     ;(txns.at(-1) as ApplicationCallTransaction).logArc4ReturnValue(returnValue)
                   }
                   appData.isCreating = false
@@ -273,7 +274,7 @@ export class ContractContext {
           },
         })
 
-        onConstructed(application, instance, getContractOptions(t!))
+        onConstructed(application, instance, getContractOptions(t))
 
         return instance
       },

--- a/src/subcontexts/ledger-context.ts
+++ b/src/subcontexts/ledger-context.ts
@@ -389,13 +389,12 @@ export class LedgerContext {
   }
 
   /**
-
- * Cache the materialised box for an application by key.
-* @internal
- * @param app - The application.
- * @param key - The key.
- * @param value - The box data.
- */
+   * Cache the materialised box for an application by key.
+   * @internal
+   * @param app - The application.
+   * @param key - The key.
+   * @param value - The box data.
+   */
   setMaterialisedBox<TValue>(app: ApplicationType | BaseContract, key: BytesCompat, value: TValue | undefined): void {
     const appId = this.getAppId(app)
     const appData = this.applicationDataMap.getOrFail(appId)

--- a/src/subcontexts/ledger-context.ts
+++ b/src/subcontexts/ledger-context.ts
@@ -30,7 +30,7 @@ import {
 import { GlobalStateCls, LocalStateForAccountCls } from '../impl/state'
 import { VoterData } from '../impl/voter-params'
 import type { PickPartial } from '../typescript-helpers'
-import { asBytes, asMaybeBytesCls, asMaybeUint64Cls, asUint64, asUint64BigInt, asUint64Cls, asUint8Array, iterBigInt } from '../util'
+import { asBytes, asMaybeBytesCls, asMaybeUint64Cls, asUint64, asUint64Cls, asUint8Array, iterBigInt } from '../util'
 
 export class LedgerContext {
   /** @internal */
@@ -51,7 +51,7 @@ export class LedgerContext {
   blocks = new Uint64Map<BlockData>()
   /** @internal */
   globalData = new GlobalData()
-  onlineStake = 0
+  onlineStake: uint64 = 0
 
   /**
    * Adds a contract to the application ID contract map.
@@ -124,19 +124,9 @@ export class LedgerContext {
     if (approvalProgram === undefined) {
       return undefined
     }
-    const entries = this.applicationDataMap.entries()
-    let next = entries.next()
-    let found = false
-    while (!next.done && !found) {
-      found = next.value[1].application.approvalProgram === approvalProgram
-      if (!found) {
-        next = entries.next()
-      }
-    }
-    if (found && next?.value) {
-      const appId = asUint64(next.value[0])
-      if (this.applicationDataMap.has(appId)) {
-        return Application(appId)
+    for (const [appId, data] of this.applicationDataMap) {
+      if (data.application.approvalProgram === approvalProgram) {
+        return Application(asUint64(appId))
       }
     }
     return undefined
@@ -152,8 +142,8 @@ export class LedgerContext {
    */
   updateAssetHolding(account: AccountType, assetId: Uint64Compat | AssetType, balance?: Uint64Compat, frozen?: boolean): void {
     const id = (asMaybeUint64Cls(assetId) ?? asUint64Cls((assetId as AssetType).id)).asAlgoTs()
-    const accountData = this.accountDataMap.get(account)!
-    const asset = this.assetDataMap.get(id)!
+    const accountData = this.accountDataMap.getOrFail(account)
+    const asset = this.assetDataMap.getOrFail(id)
     const holding = accountData.optedAssets.get(id) ?? new AssetHolding(0n, asset.defaultFrozen)
     if (balance !== undefined) holding.balance = asUint64(balance)
     if (frozen !== undefined) holding.frozen = frozen
@@ -255,7 +245,7 @@ export class LedgerContext {
    * @throws If the block is not set.
    */
   getBlockData(index: Uint64Compat): BlockData {
-    const i = asUint64BigInt(index)
+    const i = asUint64(index)
     if (this.blocks.has(i)) {
       return this.blocks.get(i)!
     }
@@ -268,7 +258,7 @@ export class LedgerContext {
    * @param key - The key.
    * @returns The global state and a boolean indicating if it was found.
    */
-  getGlobalState(app: ApplicationType | BaseContract, key: BytesCompat): [GlobalStateCls<unknown>, true] | [undefined, false] {
+  getGlobalState(app: ApplicationType | BaseContract | uint64, key: BytesCompat): [GlobalStateCls<unknown>, true] | [undefined, false] {
     const appId = this.getAppId(app)
     const appData = this.applicationDataMap.get(appId)
     if (!appData?.application.globalStates.has(key)) {
@@ -283,7 +273,7 @@ export class LedgerContext {
    * @param key - The key.
    * @param value - The value (optional).
    */
-  setGlobalState(app: ApplicationType | BaseContract, key: BytesCompat, value: Uint64Compat | BytesCompat | undefined): void {
+  setGlobalState(app: ApplicationType | BaseContract | uint64, key: BytesCompat, value: Uint64Compat | BytesCompat | undefined): void {
     const appId = this.getAppId(app)
     const appData = this.applicationDataMap.getOrFail(appId)
     const globalState = appData.application.globalStates.get(key)
@@ -308,7 +298,7 @@ export class LedgerContext {
     account: AccountType,
     key: BytesCompat,
   ): [LocalStateForAccount<unknown>, true] | [undefined, false] {
-    const appId = app instanceof Uint64Cls ? app.asAlgoTs() : this.getAppId(app as ApplicationType | BaseContract)
+    const appId = this.getAppId(app)
     const appData = this.applicationDataMap.get(appId)
     if (!appData?.application.localStateMaps.has(key)) {
       return [undefined, false]
@@ -326,7 +316,7 @@ export class LedgerContext {
    * @param value - The value (optional).
    */
   setLocalState<T>(app: ApplicationType | BaseContract | uint64, account: AccountType, key: BytesCompat, value: T | undefined): void {
-    const appId = app instanceof Uint64Cls ? app.asAlgoTs() : this.getAppId(app as ApplicationType | BaseContract)
+    const appId = this.getAppId(app)
     const appData = this.applicationDataMap.getOrFail(appId)
     if (!appData.application.localStateMaps.has(key)) {
       appData.application.localStateMaps.set(key, new AccountMap())
@@ -427,7 +417,9 @@ export class LedgerContext {
   }
 
   /** @internal */
-  private getAppId(app: ApplicationType | BaseContract): uint64 {
-    return app instanceof ApplicationCls ? app.id : this.getApplicationForContract(app as BaseContract).id
+  private getAppId(app: ApplicationType | BaseContract | uint64): uint64 {
+    if (app instanceof Uint64Cls) return app.asAlgoTs()
+    if (app instanceof ApplicationCls) return app.id
+    return this.getApplicationForContract(app as BaseContract).id
   }
 }

--- a/src/subcontexts/ledger-context.ts
+++ b/src/subcontexts/ledger-context.ts
@@ -30,7 +30,7 @@ import {
 import { GlobalStateCls, LocalStateForAccountCls } from '../impl/state'
 import { VoterData } from '../impl/voter-params'
 import type { PickPartial } from '../typescript-helpers'
-import { asBigInt, asBytes, asMaybeBytesCls, asMaybeUint64Cls, asUint64, asUint64Cls, asUint8Array, iterBigInt } from '../util'
+import { asBytes, asMaybeBytesCls, asMaybeUint64Cls, asUint64, asUint64BigInt, asUint64Cls, asUint8Array, iterBigInt } from '../util'
 
 export class LedgerContext {
   /** @internal */
@@ -255,7 +255,7 @@ export class LedgerContext {
    * @throws If the block is not set.
    */
   getBlockData(index: Uint64Compat): BlockData {
-    const i = asBigInt(index)
+    const i = asUint64BigInt(index)
     if (this.blocks.has(i)) {
       return this.blocks.get(i)!
     }

--- a/src/subcontexts/transaction-context.ts
+++ b/src/subcontexts/transaction-context.ts
@@ -347,7 +347,7 @@ export class TransactionGroup {
    * @internal
    * @throws If there is no inner transaction group being constructed.
    */
-  appendInnerTransactionGroup() {
+  appendInnerTransaction() {
     if (!this.constructingItxnGroup.length) {
       throw new InternalError('itxn next without itxn begin')
     }

--- a/src/subcontexts/transaction-context.ts
+++ b/src/subcontexts/transaction-context.ts
@@ -475,10 +475,10 @@ export class TransactionGroup {
   /** @internal */
   private _getTransaction({ type, index }: { type?: TransactionType; index?: Uint64Compat }) {
     const i = index !== undefined ? asNumber(index) : undefined
-    if (i !== undefined && i >= lazyContext.activeGroup.transactions.length) {
+    if (i !== undefined && i >= this.transactions.length) {
       throw new InternalError('Invalid group index')
     }
-    const transaction = i !== undefined ? lazyContext.activeGroup.transactions[i] : lazyContext.activeGroup.activeTransaction
+    const transaction = i !== undefined ? this.transactions[i] : this.activeTransaction
     if (type === undefined) {
       return transaction
     }

--- a/src/subcontexts/transaction-context.ts
+++ b/src/subcontexts/transaction-context.ts
@@ -32,23 +32,6 @@ import type { DeliberateAny, FunctionKeys } from '../typescript-helpers'
 import { asNumber, asUint64, asUint64BigInt } from '../util'
 import { ContractContext } from './contract-context'
 
-function ScopeGenerator(dispose: () => void) {
-  function* internal() {
-    try {
-      yield
-    } finally {
-      dispose()
-    }
-  }
-  const scope = internal()
-  scope.next()
-  return {
-    done: () => {
-      scope.return()
-    },
-  }
-}
-
 interface ExecutionScope {
   execute: <TReturn>(body: () => TReturn) => TReturn
 }
@@ -99,7 +82,7 @@ export class TransactionContext {
     activeTransactionIndex?: number,
   ): ExecutionScope {
     let activeIndex = activeTransactionIndex
-    const transactions = group.map((t) => (t instanceof DeferredAppCall ? t.txns : [t])).flat()
+    const transactions = group.flatMap((t) => (t instanceof DeferredAppCall ? t.txns : [t]))
     if (activeIndex === undefined) {
       const lastAppCall = group
         .filter((t) => t instanceof DeferredAppCall)
@@ -113,12 +96,14 @@ export class TransactionContext {
 
     this.#activeGroup = transactionGroup
 
-    const scope = ScopeGenerator(() => {
-      if (this.#activeGroup?.transactions?.length) {
-        this.groups.push(this.#activeGroup)
-      }
-      this.#activeGroup = undefined
-    })
+    const scope = {
+      done: () => {
+        if (this.#activeGroup?.transactions?.length) {
+          this.groups.push(this.#activeGroup)
+        }
+        this.#activeGroup = undefined
+      },
+    }
     return {
       execute: <TReturn>(body: () => TReturn) => {
         const result = body()
@@ -168,10 +153,11 @@ export class TransactionContext {
    * @throws If there are no transaction groups.
    */
   get lastGroup(): TransactionGroup {
-    if (this.groups.length === 0) {
+    const group = this.groups.at(-1)
+    if (group === undefined) {
       throw new InternalError('No group transactions found!')
     }
-    return this.groups.at(-1)!
+    return group
   }
 
   /**
@@ -226,12 +212,8 @@ export class TransactionContext {
     const transaction = this.lastGroup.transactions
       .filter((t) => t.type === TransactionType.ApplicationCall)
       .find((t) => asUint64BigInt(t.appId.id) === asUint64BigInt(appId))
-    let logs = []
-    if (transaction) {
-      logs = transaction.appLogs
-    } else {
-      logs = lazyContext.getApplicationData(appId).application.appLogs
-    }
+
+    const logs = transaction?.appLogs ?? lazyContext.getApplicationData(appId).application.appLogs
 
     return decodeLogs(logs, decoding)
   }
@@ -282,12 +264,13 @@ export class TransactionGroup {
     return (this.activeTransaction as ApplicationCallTransaction).backingAppId.id
   }
 
-  /* @internal */
+  /** @internal */
   get constructingItxn() {
-    if (!this.constructingItxnGroup.length) {
+    const itxn = this.constructingItxnGroup.at(-1)
+    if (!itxn) {
       throw new InternalError('itxn field without itxn begin')
     }
-    return this.constructingItxnGroup.at(-1)!
+    return itxn
   }
 
   /**
@@ -404,8 +387,8 @@ export class TransactionGroup {
     if (i !== undefined && i >= this.itxnGroups.length) {
       throw new InternalError('Invalid group index')
     }
-    const group = i !== undefined ? this.itxnGroups[i] : this.itxnGroups.at(-1)!
-    invariant(group.itxns.length > 0, 'no previous inner transactions')
+    const group = i !== undefined ? this.itxnGroups[i] : this.itxnGroups.at(-1)
+    invariant(group && group.itxns.length > 0, 'no previous inner transactions')
 
     return group
   }
@@ -416,7 +399,7 @@ export class TransactionGroup {
    * @returns The application transaction.
    */
   getApplicationCallTransaction(index?: Uint64Compat): ApplicationCallTransaction {
-    return this._getTransaction({ type: TransactionType.ApplicationCall, index }) as ApplicationCallTransaction
+    return this._getTransaction({ type: TransactionType.ApplicationCall, index })
   }
 
   /**
@@ -425,7 +408,7 @@ export class TransactionGroup {
    * @returns The asset configuration transaction.
    */
   getAssetConfigTransaction(index?: Uint64Compat): AssetConfigTransaction {
-    return this._getTransaction({ type: TransactionType.AssetConfig, index }) as AssetConfigTransaction
+    return this._getTransaction({ type: TransactionType.AssetConfig, index })
   }
 
   /**
@@ -434,7 +417,7 @@ export class TransactionGroup {
    * @returns The asset transfer transaction.
    */
   getAssetTransferTransaction(index?: Uint64Compat): AssetTransferTransaction {
-    return this._getTransaction({ type: TransactionType.AssetTransfer, index }) as AssetTransferTransaction
+    return this._getTransaction({ type: TransactionType.AssetTransfer, index })
   }
 
   /**
@@ -443,7 +426,7 @@ export class TransactionGroup {
    * @returns The asset freeze transaction.
    */
   getAssetFreezeTransaction(index?: Uint64Compat): AssetFreezeTransaction {
-    return this._getTransaction({ type: TransactionType.AssetFreeze, index }) as AssetFreezeTransaction
+    return this._getTransaction({ type: TransactionType.AssetFreeze, index })
   }
 
   /**
@@ -452,7 +435,7 @@ export class TransactionGroup {
    * @returns The key registration transaction.
    */
   getKeyRegistrationTransaction(index?: Uint64Compat): KeyRegistrationTransaction {
-    return this._getTransaction({ type: TransactionType.KeyRegistration, index }) as KeyRegistrationTransaction
+    return this._getTransaction({ type: TransactionType.KeyRegistration, index })
   }
 
   /**
@@ -461,7 +444,7 @@ export class TransactionGroup {
    * @returns The payment transaction.
    */
   getPaymentTransaction(index?: Uint64Compat): PaymentTransaction {
-    return this._getTransaction({ type: TransactionType.Payment, index }) as PaymentTransaction
+    return this._getTransaction({ type: TransactionType.Payment, index })
   }
 
   /**
@@ -473,7 +456,14 @@ export class TransactionGroup {
     return this._getTransaction({ index })
   }
   /** @internal */
-  private _getTransaction({ type, index }: { type?: TransactionType; index?: Uint64Compat }) {
+  private _getTransaction(args: { type: TransactionType.ApplicationCall; index?: Uint64Compat }): ApplicationCallTransaction
+  private _getTransaction(args: { type: TransactionType.Payment; index?: Uint64Compat }): PaymentTransaction
+  private _getTransaction(args: { type: TransactionType.AssetConfig; index?: Uint64Compat }): AssetConfigTransaction
+  private _getTransaction(args: { type: TransactionType.AssetTransfer; index?: Uint64Compat }): AssetTransferTransaction
+  private _getTransaction(args: { type: TransactionType.AssetFreeze; index?: Uint64Compat }): AssetFreezeTransaction
+  private _getTransaction(args: { type: TransactionType.KeyRegistration; index?: Uint64Compat }): KeyRegistrationTransaction
+  private _getTransaction(args: { index?: Uint64Compat }): Transaction
+  private _getTransaction({ type, index }: { type?: TransactionType; index?: Uint64Compat }): Transaction {
     const i = index !== undefined ? asNumber(index) : undefined
     if (i !== undefined && i >= this.transactions.length) {
       throw new InternalError('Invalid group index')
@@ -485,22 +475,8 @@ export class TransactionGroup {
     if (transaction.type !== type) {
       throw new InternalError(`Invalid transaction type: ${transaction.type}`)
     }
-    switch (type) {
-      case TransactionType.ApplicationCall:
-        return transaction as ApplicationCallTransaction
-      case TransactionType.Payment:
-        return transaction as PaymentTransaction
-      case TransactionType.AssetConfig:
-        return transaction as AssetConfigTransaction
-      case TransactionType.AssetTransfer:
-        return transaction as AssetTransferTransaction
-      case TransactionType.AssetFreeze:
-        return transaction as AssetFreezeTransaction
-      case TransactionType.KeyRegistration:
-        return transaction as KeyRegistrationTransaction
-      default:
-        throw new InternalError(`Invalid transaction type: ${type}`)
-    }
+
+    return transaction
   }
 }
 
@@ -520,7 +496,7 @@ export class ItxnGroup {
    * @returns The application inner transaction.
    */
   getApplicationCallInnerTxn(index?: Uint64Compat): ApplicationCallInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.ApplicationCall, index }) as ApplicationCallInnerTxn
+    return this._getInnerTxn({ type: TransactionType.ApplicationCall, index })
   }
 
   /**
@@ -529,7 +505,7 @@ export class ItxnGroup {
    * @returns The asset configuration inner transaction.
    */
   getAssetConfigInnerTxn(index?: Uint64Compat): AssetConfigInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.AssetConfig, index }) as AssetConfigInnerTxn
+    return this._getInnerTxn({ type: TransactionType.AssetConfig, index })
   }
 
   /**
@@ -538,7 +514,7 @@ export class ItxnGroup {
    * @returns The asset transfer inner transaction.
    */
   getAssetTransferInnerTxn(index?: Uint64Compat): AssetTransferInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.AssetTransfer, index }) as AssetTransferInnerTxn
+    return this._getInnerTxn({ type: TransactionType.AssetTransfer, index })
   }
 
   /**
@@ -547,7 +523,7 @@ export class ItxnGroup {
    * @returns The asset freeze inner transaction.
    */
   getAssetFreezeInnerTxn(index?: Uint64Compat): AssetFreezeInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.AssetFreeze, index }) as AssetFreezeInnerTxn
+    return this._getInnerTxn({ type: TransactionType.AssetFreeze, index })
   }
 
   /**
@@ -556,7 +532,7 @@ export class ItxnGroup {
    * @returns The key registration inner transaction.
    */
   getKeyRegistrationInnerTxn(index?: Uint64Compat): KeyRegistrationInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.KeyRegistration, index }) as KeyRegistrationInnerTxn
+    return this._getInnerTxn({ type: TransactionType.KeyRegistration, index })
   }
 
   /**
@@ -565,7 +541,7 @@ export class ItxnGroup {
    * @returns The payment inner transaction.
    */
   getPaymentInnerTxn(index?: Uint64Compat): PaymentInnerTxn {
-    return this._getInnerTxn({ type: TransactionType.Payment, index }) as PaymentInnerTxn
+    return this._getInnerTxn({ type: TransactionType.Payment, index })
   }
 
   /**
@@ -578,34 +554,28 @@ export class ItxnGroup {
   }
 
   /** @internal */
-  private _getInnerTxn({ type, index }: { type?: TransactionType; index?: Uint64Compat }) {
+  private _getInnerTxn(args: { type: TransactionType.ApplicationCall; index?: Uint64Compat }): ApplicationCallInnerTxn
+  private _getInnerTxn(args: { type: TransactionType.Payment; index?: Uint64Compat }): PaymentInnerTxn
+  private _getInnerTxn(args: { type: TransactionType.AssetConfig; index?: Uint64Compat }): AssetConfigInnerTxn
+  private _getInnerTxn(args: { type: TransactionType.AssetTransfer; index?: Uint64Compat }): AssetTransferInnerTxn
+  private _getInnerTxn(args: { type: TransactionType.AssetFreeze; index?: Uint64Compat }): AssetFreezeInnerTxn
+  private _getInnerTxn(args: { type: TransactionType.KeyRegistration; index?: Uint64Compat }): KeyRegistrationInnerTxn
+  private _getInnerTxn(args: { index?: Uint64Compat }): InnerTxn
+  private _getInnerTxn({ type, index }: { type?: TransactionType; index?: Uint64Compat }): InnerTxn {
     invariant(this.itxns.length > 0, 'no previous inner transactions')
     const i = index !== undefined ? asNumber(index) : undefined
     if (i !== undefined && i >= this.itxns.length) {
       throw new InternalError('Invalid group index')
     }
-    const transaction = i !== undefined ? this.itxns[i] : this.itxns.at(-1)!
+    const transaction = i !== undefined ? this.itxns[i] : this.itxns.at(-1)
+    invariant(transaction, 'no previous inner transactions')
+
     if (type === undefined) {
       return transaction
     }
     if (transaction.type !== type) {
       throw new InternalError(`Invalid transaction type: ${transaction.type}`)
     }
-    switch (type) {
-      case TransactionType.ApplicationCall:
-        return transaction as ApplicationCallInnerTxn
-      case TransactionType.Payment:
-        return transaction as PaymentInnerTxn
-      case TransactionType.AssetConfig:
-        return transaction as AssetConfigInnerTxn
-      case TransactionType.AssetTransfer:
-        return transaction as AssetTransferInnerTxn
-      case TransactionType.AssetFreeze:
-        return transaction as AssetFreezeInnerTxn
-      case TransactionType.KeyRegistration:
-        return transaction as KeyRegistrationInnerTxn
-      default:
-        throw new InternalError(`Invalid transaction type: ${type}`)
-    }
+    return transaction
   }
 }

--- a/src/subcontexts/transaction-context.ts
+++ b/src/subcontexts/transaction-context.ts
@@ -29,7 +29,7 @@ import type {
   Transaction,
 } from '../impl/transactions'
 import type { DeliberateAny, FunctionKeys } from '../typescript-helpers'
-import { asBigInt, asNumber, asUint64 } from '../util'
+import { asNumber, asUint64, asUint64BigInt } from '../util'
 import { ContractContext } from './contract-context'
 
 function ScopeGenerator(dispose: () => void) {
@@ -225,7 +225,7 @@ export class TransactionContext {
   exportLogs<const T extends [...LogDecoding[]]>(appId: uint64, ...decoding: T): DecodedLogs<T> {
     const transaction = this.lastGroup.transactions
       .filter((t) => t.type === TransactionType.ApplicationCall)
-      .find((t) => asBigInt(t.appId.id) === asBigInt(appId))
+      .find((t) => asUint64BigInt(t.appId.id) === asUint64BigInt(appId))
     let logs = []
     if (transaction) {
       logs = transaction.appLogs

--- a/src/test-execution-context.ts
+++ b/src/test-execution-context.ts
@@ -28,8 +28,8 @@ export class TestExecutionContext {
   #defaultSender: AccountType
   #activeLogicSigArgs: bytes[]
   #templateVars: Record<string, DeliberateAny> = {}
-  #compiledApps: Array<{ key: ConstructorFor<BaseContract>; value: uint64 }> = []
-  #compiledLogicSigs: Array<{ key: ConstructorFor<LogicSig>; value: AccountType }> = []
+  #compiledApps: Map<ConstructorFor<BaseContract>, uint64> = new Map()
+  #compiledLogicSigs: Map<ConstructorFor<LogicSig>, AccountType> = new Map()
   #applicationSpies: Array<ApplicationSpy<Contract>> = []
 
   /**
@@ -167,13 +167,13 @@ export class TestExecutionContext {
   }
 
   /**
-   * Gets a compiled application by contract.
+   * Gets the compiled application ID for a contract, or undefined if not compiled.
    *
    * @param {ConstructorFor<BaseContract>} contract - The contract class.
-   * @returns {[ConstructorFor<BaseContract>, uint64] | undefined}
+   * @returns {uint64 | undefined}
    */
-  getCompiledAppEntry(contract: ConstructorFor<BaseContract>) {
-    return this.#compiledApps.find(({ key: k }) => k === contract)
+  getCompiledApp(contract: ConstructorFor<BaseContract>): uint64 | undefined {
+    return this.#compiledApps.get(contract)
   }
 
   /**
@@ -183,12 +183,7 @@ export class TestExecutionContext {
    * @param {uint64} appId - The application ID.
    */
   setCompiledApp(c: ConstructorFor<BaseContract>, appId: uint64) {
-    const existing = this.getCompiledAppEntry(c)
-    if (existing) {
-      existing.value = appId
-    } else {
-      this.#compiledApps.push({ key: c, value: appId })
-    }
+    this.#compiledApps.set(c, appId)
   }
 
   /** @internal */
@@ -208,13 +203,13 @@ export class TestExecutionContext {
   }
 
   /**
-   * Gets a compiled logic signature.
+   * Gets the compiled logic signature account, or undefined if not compiled.
    *
    * @param {ConstructorFor<LogicSig>} logicsig - The logic signature class.
-   * @returns {[ConstructorFor<LogicSig>, Account] | undefined}
+   * @returns {AccountType | undefined}
    */
-  getCompiledLogicSigEntry(logicsig: ConstructorFor<LogicSig>) {
-    return this.#compiledLogicSigs.find(({ key: k }) => k === logicsig)
+  getCompiledLogicSig(logicsig: ConstructorFor<LogicSig>): AccountType | undefined {
+    return this.#compiledLogicSigs.get(logicsig)
   }
 
   /**
@@ -224,12 +219,7 @@ export class TestExecutionContext {
    * @param {Account} account - The account associated with the logic signature.
    */
   setCompiledLogicSig(c: ConstructorFor<LogicSig>, account: AccountType) {
-    const existing = this.getCompiledLogicSigEntry(c)
-    if (existing) {
-      existing.value = account
-    } else {
-      this.#compiledLogicSigs.push({ key: c, value: account })
-    }
+    this.#compiledLogicSigs.set(c, account)
   }
 
   /**
@@ -242,8 +232,8 @@ export class TestExecutionContext {
     this.#txnContext = new TransactionContext()
     this.#activeLogicSigArgs = []
     this.#templateVars = {}
-    this.#compiledApps = []
-    this.#compiledLogicSigs = []
+    this.#compiledApps = new Map()
+    this.#compiledLogicSigs = new Map()
     this.#applicationSpies = []
     this.#defaultSender = this.any.account({ address: this.#defaultSender.bytes }) // reset default sender account data in ledger context
     ContextManager.reset()

--- a/src/test-execution-context.ts
+++ b/src/test-execution-context.ts
@@ -26,7 +26,7 @@ export class TestExecutionContext {
   #txnContext: TransactionContext
   #valueGenerator: ValueGenerator
   #defaultSender: AccountType
-  #activeLogicSigArgs: bytes[]
+  #activeLogicSigArgs: bytes[] = []
   #templateVars: Record<string, DeliberateAny> = {}
   #compiledApps: Map<ConstructorFor<BaseContract>, uint64> = new Map()
   #compiledLogicSigs: Map<ConstructorFor<LogicSig>, AccountType> = new Map()
@@ -44,7 +44,6 @@ export class TestExecutionContext {
     this.#txnContext = new TransactionContext()
     this.#valueGenerator = new ValueGenerator()
     this.#defaultSender = this.any.account({ address: defaultSenderAddress ?? getRandomBytes(32).asAlgoTs() })
-    this.#activeLogicSigArgs = []
   }
 
   /**
@@ -120,9 +119,9 @@ export class TestExecutionContext {
   /**
    * Returns the active logic signature arguments.
    *
-   * @type {bytes[]}
+   * @type {readonly bytes[]}
    */
-  get activeLogicSigArgs(): bytes[] {
+  get activeLogicSigArgs(): readonly bytes[] {
     return this.#activeLogicSigArgs
   }
 
@@ -131,7 +130,7 @@ export class TestExecutionContext {
    *
    * @type {Record<string, DeliberateAny>}
    */
-  get templateVars(): Record<string, DeliberateAny> {
+  get templateVars(): Readonly<Record<string, DeliberateAny>> {
     return this.#templateVars
   }
 
@@ -147,9 +146,8 @@ export class TestExecutionContext {
     try {
       if (logicSig.program.length === 0) {
         return logicSig.program()
-      } else {
-        return logicSig.program(...args)
       }
+      return logicSig.program(...args)
     } finally {
       this.#activeLogicSigArgs = []
     }

--- a/src/test-execution-context.ts
+++ b/src/test-execution-context.ts
@@ -112,7 +112,7 @@ export class TestExecutionContext {
   set defaultSender(val: bytes | AccountType) {
     if (val instanceof AccountCls) {
       this.#defaultSender = val
-    } else if (this.#defaultSender.bytes !== val) {
+    } else if (!this.#defaultSender.bytes.equals(val as bytes)) {
       this.#defaultSender = new AccountCls(val as bytes)
     }
   }

--- a/src/test-transformer/node-factory.ts
+++ b/src/test-transformer/node-factory.ts
@@ -1,24 +1,31 @@
 import { ptypes } from '@algorandfoundation/puya-ts'
 import ts from 'typescript'
 import type { TypeInfo } from '../impl/encoded-types'
-import type { DeliberateAny } from '../typescript-helpers'
 import { getPropertyNameAsString, trimGenericTypeName } from './helpers'
 
 const factory = ts.factory
+
+const callRuntimeHelper = (name: string, args: ts.Expression[]) =>
+  factory.createCallExpression(
+    factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier(name)),
+    undefined,
+    args,
+  )
+
 /** @internal */
 export const nodeFactory = {
   importHelpers(testingPackageName: string) {
     return [
       factory.createImportDeclaration(
         undefined,
-        factory.createImportClause(false, undefined, factory.createNamespaceImport(factory.createIdentifier('runtimeHelpers'))),
+        factory.createImportClause(undefined, undefined, factory.createNamespaceImport(factory.createIdentifier('runtimeHelpers'))),
         factory.createStringLiteral(`${testingPackageName}/runtime-helpers`),
         undefined,
       ),
       factory.createImportDeclaration(
         undefined,
         factory.createImportClause(
-          false,
+          undefined,
           undefined,
           factory.createNamedImports([factory.createImportSpecifier(false, undefined, factory.createIdentifier('arc4'))]),
         ),
@@ -29,36 +36,17 @@ export const nodeFactory = {
   },
 
   switchableValue(x: ts.Expression) {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('switchableValue')),
-      undefined,
-      [x],
-    )
+    return callRuntimeHelper('switchableValue', [x])
   },
   binaryOp(left: ts.Expression, right: ts.Expression, op: string) {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('binaryOp')),
-      undefined,
-      [left, right, factory.createStringLiteral(op)],
-    )
+    return callRuntimeHelper('binaryOp', [left, right, factory.createStringLiteral(op)])
   },
   augmentedAssignmentBinaryOp(left: ts.Expression, right: ts.Expression, op: string) {
-    return factory.createAssignment(
-      left,
-      factory.createCallExpression(
-        factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('binaryOp')),
-        undefined,
-        [left, right, factory.createStringLiteral(op.replace('=', ''))],
-      ),
-    )
+    return factory.createAssignment(left, callRuntimeHelper('binaryOp', [left, right, factory.createStringLiteral(op.replace(/=$/, ''))]))
   },
 
   prefixUnaryOp(operand: ts.Expression, op: string) {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('unaryOp')),
-      undefined,
-      [operand, factory.createStringLiteral(op)],
-    )
+    return callRuntimeHelper('unaryOp', [operand, factory.createStringLiteral(op)])
   },
 
   attachMetaData(
@@ -78,39 +66,29 @@ export const nodeFactory = {
       factory.createPropertyAssignment('returnType', factory.createStringLiteral(returnType)),
     ])
     return factory.createExpressionStatement(
-      factory.createCallExpression(
-        factory.createPropertyAccessExpression(factory.createIdentifier('runtimeHelpers'), factory.createIdentifier('attachAbiMetadata')),
-        undefined,
-        [
-          classIdentifier,
-          methodName,
-          metadata,
-          factory.createStringLiteral(sourceFileName),
-          factory.createStringLiteral(classIdentifier.text),
-        ],
-      ),
+      callRuntimeHelper('attachAbiMetadata', [
+        classIdentifier,
+        methodName,
+        metadata,
+        factory.createStringLiteral(sourceFileName),
+        factory.createStringLiteral(classIdentifier.text),
+      ]),
     )
   },
 
   captureGenericTypeInfo(x: ts.Expression, info: string) {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(
-        factory.createIdentifier('runtimeHelpers'),
-        factory.createIdentifier('captureGenericTypeInfo'),
-      ),
-      undefined,
-      [x, factory.createStringLiteral(info)],
-    )
+    return callRuntimeHelper('captureGenericTypeInfo', [x, factory.createStringLiteral(info)])
   },
 
   instantiateEncodedType(node: ts.NewExpression, typeInfo?: TypeInfo) {
-    const infoString = JSON.stringify(typeInfo)
     const classIdentifier = node.expression.getText().replace('arc4.', '')
-    return factory.createNewExpression(
-      factory.createIdentifier(`arc4.${trimGenericTypeName(typeInfo?.name ?? classIdentifier)}`),
-      node.typeArguments,
-      [infoString ? factory.createStringLiteral(infoString) : undefined, ...(node.arguments ?? [])].filter((arg) => !!arg),
-    )
+    const arc4ClassIdentifier = factory.createIdentifier(`arc4.${trimGenericTypeName(typeInfo?.name ?? classIdentifier)}`)
+    const args = [...(node.arguments ?? [])]
+    if (typeInfo) {
+      args.unshift(factory.createStringLiteral(JSON.stringify(typeInfo)))
+    }
+
+    return factory.createNewExpression(arc4ClassIdentifier, node.typeArguments, args)
   },
 
   callStubbedFunction(node: ts.CallExpression, typeInfo?: TypeInfo | TypeInfo[]) {
@@ -129,23 +107,25 @@ export const nodeFactory = {
           factory.createPropertyAssignment('contract', factory.createStringLiteral(typeParams[0].declaredIn.fullName)),
         ]),
       ])
-    } else if (
+    }
+    if (
       node.arguments.length === 1 &&
       ts.isPropertyAccessExpression(node.arguments[0]) &&
       ts.isPropertyAccessExpression(node.arguments[0].expression)
     ) {
-      const contractIdentifier = node.arguments[0].expression.expression
       return factory.updateCallExpression(node, node.expression, node.typeArguments, [
         factory.createObjectLiteralExpression([
           factory.createPropertyAssignment('method', node.arguments[0]),
-          factory.createPropertyAssignment('contract', contractIdentifier),
+          factory.createPropertyAssignment('contract', node.arguments[0].expression.expression),
         ]),
       ])
-    } else {
+    }
+    if (node.arguments.length === 1) {
       return factory.updateCallExpression(node, node.expression, node.typeArguments, [
         factory.createObjectLiteralExpression([factory.createPropertyAssignment('method', node.arguments[0])]),
       ])
     }
+    return node
   },
 
   callAbiCallFunction(node: ts.CallExpression, typeParams: ptypes.PType[]) {
@@ -167,7 +147,8 @@ export const nodeFactory = {
     ) {
       const contractIdentifier = node.arguments[0].expression.expression
       return factory.updateCallExpression(node, node.expression, node.typeArguments, [...node.arguments, contractIdentifier])
-    } else if (
+    }
+    if (
       node.arguments.length === 1 &&
       typeParams.length === 1 &&
       typeParams[0] instanceof ptypes.FunctionPType &&
@@ -179,4 +160,4 @@ export const nodeFactory = {
     }
     return node
   },
-} satisfies Record<string, (...args: DeliberateAny[]) => ts.Node | ts.Node[]>
+}

--- a/src/test-transformer/node-factory.ts
+++ b/src/test-transformer/node-factory.ts
@@ -134,11 +134,11 @@ export const nodeFactory = {
       ts.isPropertyAccessExpression(node.arguments[0]) &&
       ts.isPropertyAccessExpression(node.arguments[0].expression)
     ) {
-      const contractIdenifier = node.arguments[0].expression.expression
+      const contractIdentifier = node.arguments[0].expression.expression
       return factory.updateCallExpression(node, node.expression, node.typeArguments, [
         factory.createObjectLiteralExpression([
           factory.createPropertyAssignment('method', node.arguments[0]),
-          factory.createPropertyAssignment('contract', contractIdenifier),
+          factory.createPropertyAssignment('contract', contractIdentifier),
         ]),
       ])
     } else {
@@ -165,8 +165,8 @@ export const nodeFactory = {
       ts.isPropertyAccessExpression(node.arguments[0]) &&
       ts.isPropertyAccessExpression(node.arguments[0].expression)
     ) {
-      const contractIdenifier = node.arguments[0].expression.expression
-      return factory.updateCallExpression(node, node.expression, node.typeArguments, [...node.arguments, contractIdenifier])
+      const contractIdentifier = node.arguments[0].expression.expression
+      return factory.updateCallExpression(node, node.expression, node.typeArguments, [...node.arguments, contractIdentifier])
     } else if (
       node.arguments.length === 1 &&
       typeParams.length === 1 &&

--- a/src/test-transformer/visitors.ts
+++ b/src/test-transformer/visitors.ts
@@ -15,7 +15,7 @@ import {
 
 const { factory } = ts
 
-const algotsModuleRegExp = new RegExp(/^("|')@algorandfoundation\/algorand-typescript(\/|"|')/)
+const algotsModuleRegExp = /^("|')@algorandfoundation\/algorand-typescript(\/|"|')/
 const algotsModuleSpecifier = '@algorandfoundation/algorand-typescript'
 const testingInternalModuleSpecifier = (testingPackageName: string) => `${testingPackageName}/internal`
 const algotsModulePaths = [
@@ -32,12 +32,12 @@ const algotsTestingModulePaths = (testingPackageName: string) => [
 const testingExamplePath = `${path.sep}algorand-typescript-testing${path.sep}examples${path.sep}`
 
 type VisitorHelper = {
+  config: TransformerConfig
   additionalStatements: ts.Statement[]
   resolveType(node: ts.Node): ptypes.PType
   resolveTypeParameters(node: ts.CallExpression): ptypes.PType[]
   sourceLocation(node: ts.Node): SourceLocation
   tryGetSymbol(node: ts.Node): ts.Symbol | undefined
-  getConfig(): TransformerConfig
 }
 
 type Context = ts.TransformationContext & { currentDirectory: string }
@@ -59,11 +59,12 @@ export class SourceFileVisitor {
     const programDir = AbsolutePath.resolve({ path: program.getCurrentDirectory() })
     const typeResolver = new TypeResolver(typeChecker, programDir)
     this.helper = {
+      config,
       additionalStatements: [],
       resolveType(node: ts.Node): ptypes.PType {
         const sourceLocation = this.sourceLocation(node)
         try {
-          return loggingContext.run(() => typeResolver.resolve(node, sourceLocation!))
+          return loggingContext.run(() => typeResolver.resolve(node, sourceLocation))
         } catch (e) {
           const err = e as Error
           if (
@@ -89,16 +90,13 @@ export class SourceFileVisitor {
           return SourceLocation.None
         }
       },
-      getConfig(): TransformerConfig {
-        return config
-      },
     }
   }
 
   public result(): ts.SourceFile {
     const updatedSourceFile = ts.visitNode(this.sourceFile, this.visit) as ts.SourceFile
     return factory.updateSourceFile(updatedSourceFile, [
-      ...nodeFactory.importHelpers(this.helper.getConfig().testingPackageName),
+      ...nodeFactory.importHelpers(this.helper.config.testingPackageName),
       ...updatedSourceFile.statements,
       ...this.helper.additionalStatements,
     ])
@@ -106,10 +104,10 @@ export class SourceFileVisitor {
 
   private visit = (node: ts.Node): ts.Node => {
     if (ts.isImportDeclaration(node)) {
-      return new ImportDeclarationVisitor(node, this.helper).result()
+      return visitImportDeclaration(node, this.helper)
     }
     if (ts.isFunctionLike(node)) {
-      return new FunctionLikeDecVisitor(this.context, this.helper, node).result()
+      return new FunctionOrMethodVisitor(this.context, this.helper, node).result()
     }
     if (ts.isClassDeclaration(node)) {
       return new ClassVisitor(this.context, this.helper, node).result()
@@ -118,43 +116,43 @@ export class SourceFileVisitor {
     // capture generic type info for variable initialising outside class and function declarations
     // e.g. `const x = new Uint<32>(42)
     if (ts.isVariableDeclaration(node) && node.initializer) {
-      return new VariableInitializerVisitor(this.context, this.helper, node).result()
+      return visitVariableInitializer(node, this.context, this.helper)
     }
 
     return ts.visitEachChild(node, this.visit, this.context)
   }
 }
 
-class ImportDeclarationVisitor {
-  constructor(
-    private declarationNode: ts.ImportDeclaration,
-    private helper: VisitorHelper,
-  ) {}
+const visitImportDeclaration = (node: ts.ImportDeclaration, helper: VisitorHelper): ts.ImportDeclaration => {
+  const moduleSpecifier = node.moduleSpecifier.getText()
+  if (node.importClause?.phaseModifier === ts.SyntaxKind.TypeKeyword || !algotsModuleRegExp.test(moduleSpecifier)) return node
 
-  public result(): ts.ImportDeclaration {
-    const moduleSpecifier = this.declarationNode.moduleSpecifier.getText()
-    if (this.declarationNode.importClause?.isTypeOnly || !algotsModuleRegExp.test(moduleSpecifier)) return this.declarationNode
+  const namedBindings = node.importClause?.namedBindings
+  // remove `arc4` from named bindings, as it is explicitly imported in the `importHelpers` method
+  const nonTypeNamedBindings =
+    namedBindings && ts.isNamedImports(namedBindings) ? namedBindings.elements.filter((e) => !e.isTypeOnly && e.name.text !== 'arc4') : []
+  return factory.createImportDeclaration(
+    node.modifiers,
+    nonTypeNamedBindings.length
+      ? factory.createImportClause(undefined, node.importClause?.name, factory.createNamedImports(nonTypeNamedBindings))
+      : node.importClause,
+    factory.createStringLiteral(
+      moduleSpecifier
+        .replace(algotsModuleSpecifier, testingInternalModuleSpecifier(helper.config.testingPackageName))
+        .replace(/^("|')/, '')
+        .replace(/("|')$/, ''),
+    ),
+    node.attributes,
+  )
+}
 
-    const namedBindings = this.declarationNode.importClause?.namedBindings
-    // remove `arc4` from named bindings, as it is explicitly imported in the `importHelpers` method
-    const nonTypeNamedBindings =
-      namedBindings && ts.isNamedImports(namedBindings)
-        ? (namedBindings as ts.NamedImports).elements.filter((e) => !e.isTypeOnly && e.name.getText() !== 'arc4')
-        : []
-    return factory.createImportDeclaration(
-      this.declarationNode.modifiers,
-      nonTypeNamedBindings.length
-        ? factory.createImportClause(false, this.declarationNode.importClause?.name, factory.createNamedImports(nonTypeNamedBindings))
-        : this.declarationNode.importClause,
-      factory.createStringLiteral(
-        moduleSpecifier
-          .replace(algotsModuleSpecifier, testingInternalModuleSpecifier(this.helper.getConfig().testingPackageName))
-          .replace(/^("|')/, '')
-          .replace(/("|')$/, ''),
-      ),
-      this.declarationNode.attributes,
-    )
-  }
+const visitVariableInitializer = (node: ts.VariableDeclaration, context: Context, helper: VisitorHelper): ts.VariableDeclaration => {
+  const initializerNode = node.initializer
+  if (!initializerNode) return node
+
+  const updatedInitializer = new ExpressionVisitor(context, helper, initializerNode).result()
+  if (updatedInitializer === initializerNode) return node
+  return factory.updateVariableDeclaration(node, node.name, node.exclamationToken, node.type, updatedInitializer)
 }
 
 class ExpressionVisitor {
@@ -232,33 +230,12 @@ class ExpressionVisitor {
     return ts.visitEachChild(node, this.visit, this.context)
   }
 }
-class VariableInitializerVisitor {
-  constructor(
-    private context: Context,
-    private helper: VisitorHelper,
-    private declarationNode: ts.VariableDeclaration,
-  ) {}
-
-  public result(): ts.VariableDeclaration {
-    const initializerNode = this.declarationNode.initializer
-    if (!initializerNode) return this.declarationNode
-
-    const updatedInitializer = new ExpressionVisitor(this.context, this.helper, initializerNode).result()
-    if (updatedInitializer === initializerNode) return this.declarationNode
-    return factory.updateVariableDeclaration(
-      this.declarationNode,
-      this.declarationNode.name,
-      this.declarationNode.exclamationToken,
-      this.declarationNode.type,
-      updatedInitializer,
-    )
-  }
-}
 
 class FunctionOrMethodVisitor {
   constructor(
     protected context: Context,
     protected helper: VisitorHelper,
+    private funcNode: ts.SignatureDeclaration,
   ) {}
   protected visit = (node: ts.Node): ts.Node => {
     return ts.visitEachChild(this.updateNode(node), this.visit, this.context)
@@ -301,7 +278,7 @@ class FunctionOrMethodVisitor {
      * ```
      */
     if (ts.isVariableDeclaration(node) && node.initializer) {
-      return new VariableInitializerVisitor(this.context, this.helper, node).result()
+      return visitVariableInitializer(node, this.context, this.helper)
     }
 
     /*
@@ -325,32 +302,9 @@ class FunctionOrMethodVisitor {
 
     return node
   }
-}
-
-class FunctionLikeDecVisitor extends FunctionOrMethodVisitor {
-  constructor(
-    context: Context,
-    helper: VisitorHelper,
-    private funcNode: ts.SignatureDeclaration,
-  ) {
-    super(context, helper)
-  }
 
   public result(): ts.SignatureDeclaration {
     return ts.visitNode(this.funcNode, this.visit) as ts.SignatureDeclaration
-  }
-}
-class MethodDecVisitor extends FunctionOrMethodVisitor {
-  constructor(
-    context: Context,
-    helper: VisitorHelper,
-    private methodNode: ts.MethodDeclaration,
-  ) {
-    super(context, helper)
-  }
-
-  public result(): ts.MethodDeclaration {
-    return ts.visitNode(this.methodNode, this.visit) as ts.MethodDeclaration
   }
 }
 
@@ -372,7 +326,7 @@ class ClassVisitor {
 
   private get sourceFileName(): string {
     if (!this._sourceFileName) {
-      this._sourceFileName = normalisePath(this.classDec.parent.getSourceFile().fileName, this.context.currentDirectory)
+      this._sourceFileName = normalisePath(this.classDec.getSourceFile().fileName, this.context.currentDirectory)
     }
     return this._sourceFileName
   }
@@ -390,7 +344,7 @@ class ClassVisitor {
         }
       }
 
-      return new MethodDecVisitor(this.context, this.helper, node).result()
+      return new FunctionOrMethodVisitor(this.context, this.helper, node).result()
     }
 
     if (ts.isCallExpression(node)) {
@@ -442,7 +396,7 @@ const getGenericTypeInfo = (type: ptypes.PType, sourceLocation?: SourceLocation)
       `${sourceLocation}: Union types are not valid as a variable, parameter, return, or property type. Expression type is ${type.name}`,
     )
   }
-  let typeName = type?.name ?? type?.toString() ?? 'unknown'
+  let typeName = type.name
   let genericArgs: TypeInfo[] | Record<string, TypeInfo> = []
 
   if (instanceOfAny(type, ptypes.LocalStateType, ptypes.GlobalStateType, ptypes.BoxPType)) {
@@ -461,12 +415,12 @@ const getGenericTypeInfo = (type: ptypes.PType, sourceLocation?: SourceLocation)
       ptypes.FixedArrayPType,
     )
   ) {
-    const entries = []
-    entries.push(['elementType', getGenericTypeInfo(type.elementType, sourceLocation)])
-    if (instanceOfAny(type, ptypes.StaticArrayType, ptypes.FixedArrayPType)) {
-      entries.push(['size', { name: type.arraySize.toString() }])
+    genericArgs = {
+      elementType: getGenericTypeInfo(type.elementType, sourceLocation),
+      ...(instanceOfAny(type, ptypes.StaticArrayType, ptypes.FixedArrayPType) && {
+        size: { name: type.arraySize.toString() },
+      }),
     }
-    genericArgs = Object.fromEntries(entries)
   } else if (type instanceof ptypes.UFixedNxMType) {
     genericArgs = { n: { name: type.n.toString() }, m: { name: type.m.toString() } }
   } else if (type instanceof ptypes.UintNType) {
@@ -492,20 +446,18 @@ const getGenericTypeInfo = (type: ptypes.PType, sourceLocation?: SourceLocation)
   }
 
   const result: TypeInfo = { name: typeName }
-  if (genericArgs && (genericArgs.length || Object.keys(genericArgs).length)) {
+  if (genericArgs.length || Object.keys(genericArgs).length) {
     result.genericArgs = genericArgs
   }
   return result
 }
 
+const stubbedFunctionNames = ['convertBytes', 'decodeArc4', 'encodeArc4', 'emit', 'methodSelector', 'sizeOf', 'abiCall', 'clone']
 const tryGetStubbedFunctionName = (node: ts.CallExpression, helper: VisitorHelper): string | undefined => {
   if (node.expression.kind !== ts.SyntaxKind.Identifier && !ts.isPropertyAccessExpression(node.expression)) return undefined
-  const identityExpression = ts.isPropertyAccessExpression(node.expression)
-    ? (node.expression as ts.PropertyAccessExpression).name
-    : (node.expression as ts.Identifier)
+  const identityExpression = ts.isPropertyAccessExpression(node.expression) ? node.expression.name : node.expression
   const functionName = tryGetAlgoTsSymbolName(identityExpression, helper)
   if (functionName === undefined) return undefined
-  const stubbedFunctionNames = ['convertBytes', 'decodeArc4', 'encodeArc4', 'emit', 'methodSelector', 'sizeOf', 'abiCall', 'clone']
 
   if (stubbedFunctionNames.includes(functionName)) {
     if (ts.isPropertyAccessExpression(node.expression)) {
@@ -536,7 +488,7 @@ const tryGetAlgoTsSymbolName = (node: ts.Node, helper: VisitorHelper): string | 
     return symbol.getName()
 
   // If the symbol is from algorand-typescript-testing package, return undefined as they do not need to be processed
-  if (algotsTestingModulePaths(helper.getConfig().testingPackageName).some((path) => sourceFileName.includes(path))) return undefined
+  if (algotsTestingModulePaths(helper.config.testingPackageName).some((path) => sourceFileName.includes(path))) return undefined
 
   return symbol.getName()
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -103,7 +103,7 @@ export const asMaybeBytesCls = (val: DeliberateAny) => tryFromCompat(() => Bytes
 
 /** @internal */
 export const binaryStringToBytes = (s: string): BytesCls =>
-  BytesCls.fromCompat(new Uint8Array(s.match(/.{1,8}/g)!.map((x) => parseInt(x, 2))))
+  BytesCls.fromCompat(new Uint8Array((s.match(/.{1,8}/g) ?? []).map((x) => parseInt(x, 2))))
 
 /** @internal */
 export const getRandomNumber = (min: number, max: number): number => {
@@ -119,7 +119,7 @@ export const getRandomBigInt = (min: number | bigint, max: number | bigint): big
 }
 
 /** @internal */
-export const getRandomBytes = (length: number): BytesCls => asBytesCls(Bytes(randomBytes(length)))
+export const getRandomBytes = (length: number): BytesCls => asBytesCls(randomBytes(length))
 
 /** @internal */
 export const flattenAsBytes = (arr: StubBytesCompat | StubBytesCompat[]): bytes => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,11 +39,10 @@ export function toExternalValue(val: biguint): bigint
 export function toExternalValue(val: bytes): Uint8Array
 export function toExternalValue(val: string): string
 export function toExternalValue(val: uint64 | biguint | bytes | string) {
-  const instance = val as unknown
-  if (instance instanceof BytesCls) return instance.asUint8Array()
-  if (instance instanceof Uint64Cls) return instance.asBigInt()
-  if (instance instanceof BigUintCls) return instance.asBigInt()
-  if (typeof val === 'string') return val
+  if (val instanceof BytesCls) return val.asUint8Array()
+  if (val instanceof Uint64Cls) return val.asBigInt()
+  if (val instanceof BigUintCls) return val.asBigInt()
+  return val
 }
 
 /** @internal */
@@ -55,6 +54,9 @@ export function* iterBigInt(start: bigint, end: bigint): Generator<bigint> {
 
 /** @internal */
 export const asUint64BigInt = (v: StubUint64Compat): bigint => asUint64Cls(v).asBigInt()
+
+/** @internal */
+export const asUint64Bytes = (v: StubUint64Compat) => asUint64Cls(v).toBytes()
 
 /** @internal */
 export const asNumber = (v: StubUint64Compat): number => asUint64Cls(v).asNumber()
@@ -81,48 +83,23 @@ export const asBytes = (val: StubBytesCompat | Uint8Array) => asBytesCls(val).as
 /** @internal */
 export const asUint8Array = (val: StubBytesCompat | Uint8Array) => asBytesCls(val).asUint8Array()
 
-/** @internal */
-export const asMaybeUint64Cls = (val: DeliberateAny, throwsOverflow: boolean = true) => {
+const tryFromCompat = <T>(fn: () => T, throwsOverflow = true): T | undefined => {
   try {
-    return Uint64Cls.fromCompat(val)
+    return fn()
   } catch (e) {
-    if (e instanceof InternalError) {
-      // swallow error and return undefined
-    } else if (!throwsOverflow && e instanceof AvmError && e.message.includes('overflow')) {
-      // swallow overflow error and return undefined
-    } else {
-      throw e
-    }
+    if (e instanceof InternalError) return undefined
+    if (!throwsOverflow && e instanceof AvmError && e.message.includes('overflow')) return undefined
+    throw e
   }
-  return undefined
 }
 
 /** @internal */
-export const asMaybeBigUintCls = (val: DeliberateAny) => {
-  try {
-    return BigUintCls.fromCompat(val)
-  } catch (e) {
-    if (e instanceof InternalError) {
-      // swallow error and return undefined
-    } else {
-      throw e
-    }
-  }
-  return undefined
-}
+export const asMaybeUint64Cls = (val: DeliberateAny, throwsOverflow: boolean = true) =>
+  tryFromCompat(() => Uint64Cls.fromCompat(val), throwsOverflow)
 /** @internal */
-export const asMaybeBytesCls = (val: DeliberateAny) => {
-  try {
-    return BytesCls.fromCompat(val)
-  } catch (e) {
-    if (e instanceof InternalError) {
-      // swallow error and return undefined
-    } else {
-      throw e
-    }
-  }
-  return undefined
-}
+export const asMaybeBigUintCls = (val: DeliberateAny) => tryFromCompat(() => BigUintCls.fromCompat(val))
+/** @internal */
+export const asMaybeBytesCls = (val: DeliberateAny) => tryFromCompat(() => BytesCls.fromCompat(val))
 
 /** @internal */
 export const binaryStringToBytes = (s: string): BytesCls =>

--- a/src/util.ts
+++ b/src/util.ts
@@ -127,9 +127,8 @@ export const flattenAsBytes = (arr: StubBytesCompat | StubBytesCompat[]): bytes 
 }
 
 const NoValue = Symbol('no-value')
-type LazyInstance<T> = () => T
 /** @internal */
-export const Lazy = <T>(factory: () => T): LazyInstance<T> => {
+export const Lazy = <T>(factory: () => T): (() => T) => {
   let val: T | typeof NoValue = NoValue
 
   return () => {
@@ -144,13 +143,8 @@ const ObjectReferenceSymbol = Symbol('ObjectReference')
 const objectRefIter = iterBigInt(1001n, MAX_UINT512)
 /** @internal */
 export const getObjectReference = (obj: DeliberateAny): bigint => {
-  const tryGetReference = (obj: DeliberateAny): bigint | undefined => {
-    const s = Object.getOwnPropertySymbols(obj).find((s) => s.toString() === ObjectReferenceSymbol.toString())
-    return s ? obj[s] : ObjectReferenceSymbol in obj ? obj[ObjectReferenceSymbol] : undefined
-  }
-  const existingRef = tryGetReference(obj)
-  if (existingRef !== undefined) {
-    return existingRef
+  if (ObjectReferenceSymbol in obj) {
+    return obj[ObjectReferenceSymbol]
   }
   const ref = objectRefIter.next().value
   Object.defineProperty(obj, ObjectReferenceSymbol, {
@@ -200,14 +194,6 @@ export const uint8ArrayToNumber = (value: Uint8Array): number => {
  * @param {unknown} condition - The condition to assert
  * @param {string} [message] - Optional error message if assertion fails
  * @throws {AssertError} Throws if condition is falsy
- *
- * @example
- * ```ts
- * const value: string | undefined = "test";
- * assert(value !== undefined);
- *
- * assert(false, "This will throw"); // throws AssertError: This will throw
- * ```
  */
 /** @internal */
 export function assert(condition: unknown, message?: string): asserts condition {
@@ -223,13 +209,6 @@ export function assert(condition: unknown, message?: string): asserts condition 
  * @param {string} [message] - Optional error message. Defaults to "err opcode executed"
  * @throws {AvmError} Always throws an AvmError
  * @returns {never} Function never returns normally
- *
- * @example
- * ```ts
- * if (amount < 0) {
- *   err("Invalid amount"); // Throws AvmError: Invalid amount
- * }
- * ```
  */
 /** @internal */
 export function err(message?: string): never {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,7 +54,7 @@ export function* iterBigInt(start: bigint, end: bigint): Generator<bigint> {
 }
 
 /** @internal */
-export const asBigInt = (v: StubUint64Compat): bigint => asUint64Cls(v).asBigInt()
+export const asUint64BigInt = (v: StubUint64Compat): bigint => asUint64Cls(v).asBigInt()
 
 /** @internal */
 export const asNumber = (v: StubUint64Compat): number => asUint64Cls(v).asNumber()

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import type { biguint, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
 import { randomBytes } from 'crypto'
-import { BITS_IN_BYTE, MAX_BYTES_SIZE, MAX_UINT512, MAX_UINT8, UINT512_SIZE } from './constants'
+import { BITS_IN_BYTE, MAX_BYTES_SIZE, MAX_UINT512, UINT512_SIZE } from './constants'
 import { AssertError, AvmError, InternalError } from './errors'
 import type { StubBigUintCompat, StubBytesCompat, StubUint64Compat } from './impl/primitives'
 import { BigUintCls, Bytes, BytesCls, Uint64Cls } from './impl/primitives'
@@ -137,10 +137,8 @@ export const getRandomNumber = (min: number, max: number): number => {
 export const getRandomBigInt = (min: number | bigint, max: number | bigint): bigint => {
   const bigIntMin = BigInt(min)
   const bigIntMax = BigInt(max)
-  const randomValue = [...Array(UINT512_SIZE / BITS_IN_BYTE).keys()]
-    .map(() => getRandomNumber(0, MAX_UINT8))
-    .reduce((acc, x) => acc * 256n + BigInt(x), 0n)
-  return (randomValue % (bigIntMax - bigIntMin)) + bigIntMin
+  const randomValue = randomBytes(UINT512_SIZE / BITS_IN_BYTE).reduce((acc, x) => acc * 256n + BigInt(x), 0n)
+  return (randomValue % (bigIntMax - bigIntMin + 1n)) + bigIntMin
 }
 
 /** @internal */
@@ -190,7 +188,7 @@ export const getObjectReference = (obj: DeliberateAny): bigint => {
 /** @internal */
 export const combineIntoMaxBytePages = (pages: bytes[]): bytes[] => {
   const combined = pages.reduce((acc, x) => acc.concat(x), asBytesCls(''))
-  const totalPages = (asNumber(combined.length) + MAX_BYTES_SIZE - 1) / MAX_BYTES_SIZE
+  const totalPages = Math.ceil(asNumber(combined.length) / MAX_BYTES_SIZE)
   const result = [] as bytes[]
   for (let i = 0; i < totalPages; i++) {
     const start = i * MAX_BYTES_SIZE
@@ -214,7 +212,9 @@ export const concatUint8Arrays = (...values: Uint8Array[]): Uint8Array => {
 
 /** @internal */
 export const uint8ArrayToNumber = (value: Uint8Array): number => {
-  return value.reduce((acc, x) => acc * 256 + x, 0)
+  const result = value.reduce((acc, x) => acc * 256n + BigInt(x), 0n)
+  if (result > Number.MAX_SAFE_INTEGER) throw new RangeError(`Value ${result} exceeds maximum safe integer limit`)
+  return Number(result)
 }
 
 /**

--- a/src/value-generators/avm.ts
+++ b/src/value-generators/avm.ts
@@ -15,7 +15,7 @@ import { InternalError } from '../errors'
 import { BigUint, Bytes, Uint64 } from '../impl/primitives'
 import type { AssetData } from '../impl/reference'
 import { Account, AccountData, ApplicationCls, ApplicationData, AssetCls, getDefaultAssetData } from '../impl/reference'
-import { asBigInt, asBigUintCls, asUint64, asUint64Cls, getRandomBigInt, getRandomBytes } from '../util'
+import { asBigUintCls, asUint64, asUint64BigInt, asUint64Cls, getRandomBigInt, getRandomBytes } from '../util'
 
 type AccountContextData = Partial<AccountData['account']> & {
   address?: bytes
@@ -38,8 +38,8 @@ export class AvmValueGenerator {
    * @returns {uint64} - A random uint64 value.
    */
   uint64(minValue: Uint64Compat = 0n, maxValue: Uint64Compat = MAX_UINT64): uint64 {
-    const min = asBigInt(minValue)
-    const max = asBigInt(maxValue)
+    const min = asUint64BigInt(minValue)
+    const max = asUint64BigInt(maxValue)
     if (max > MAX_UINT64) {
       throw new InternalError('maxValue must be less than or equal to 2n ** 64n - 1n')
     }
@@ -121,7 +121,7 @@ export class AvmValueGenerator {
     }
     if (input?.optedApplications) {
       for (const app of input.optedApplications) {
-        data.optedApplications.set(asBigInt(app.id), app)
+        data.optedApplications.set(asUint64BigInt(app.id), app)
       }
     }
     return account

--- a/tests/arc4/encode-decode-arc4.algo.spec.ts
+++ b/tests/arc4/encode-decode-arc4.algo.spec.ts
@@ -1,4 +1,4 @@
-import type { biguint, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
+import type { Account, Application, Asset, biguint, bytes, uint64 } from '@algorandfoundation/algorand-typescript'
 import { arc4, assertMatch, Bytes } from '@algorandfoundation/algorand-typescript'
 import type { StaticBytes, UFixed, Uint64 } from '@algorandfoundation/algorand-typescript/arc4'
 import {
@@ -18,7 +18,7 @@ import {
 import { itob } from '@algorandfoundation/algorand-typescript/op'
 import { encodingUtil } from '@algorandfoundation/puya-ts'
 import { describe, expect, test } from 'vitest'
-import { MAX_UINT128 } from '../../src/constants'
+import { ABI_RETURN_VALUE_LOG_PREFIX, MAX_UINT128 } from '../../src/constants'
 import type { StubBytesCompat } from '../../src/impl/primitives'
 import type { DeliberateAny } from '../../src/typescript-helpers'
 import { asBytes } from '../../src/util'
@@ -185,6 +185,60 @@ describe('decodeArc4', () => {
     expect(decodeArc4<string[]>(Bytes`${lenPrefix}${offsetHeader}${dBytes}`)).toEqual([d])
     assertMatch(decodeArc4<TestObj[]>(Bytes`${lenPrefix}${offsetHeader}${eBytes}`), [e])
     expect(JSON.stringify(decodeArc4<Address[]>(Bytes`${lenPrefix}${fBytes}`))).toEqual(JSON.stringify([f]))
+  })
+})
+
+describe('decodeArc4 with prefix=log', () => {
+  // ABI return values (e.g. from `abiCall`) arrive as the 4-byte log prefix followed by the encoded value.
+  // These tests assert that decodeArc4 correctly strips the prefix for each natively-typed return.
+
+  const withLogPrefix = (raw: bytes | Uint8Array) => ABI_RETURN_VALUE_LOG_PREFIX.concat(asBytes(raw))
+
+  const lengthPrefixed = (data: Uint8Array): bytes =>
+    asBytes(new Uint8Array([...encodingUtil.bigIntToUint8Array(BigInt(data.length), 2), ...data]))
+
+  test('uint64', () => {
+    const raw = encodingUtil.bigIntToUint8Array(234234n, 8)
+    expect(decodeArc4<uint64>(withLogPrefix(raw), 'log')).toEqual(234234)
+  })
+
+  test('biguint', () => {
+    const raw = encodingUtil.bigIntToUint8Array(340943934n, 64)
+    expect(decodeArc4<biguint>(withLogPrefix(raw), 'log')).toEqual(340943934n)
+  })
+
+  test('boolean', () => {
+    expect(decodeArc4<boolean>(withLogPrefix(new Uint8Array([0x80])), 'log')).toEqual(true)
+  })
+
+  test('bytes', () => {
+    const raw = new Uint8Array([1, 2, 3, 4, 5])
+    expect(decodeArc4<bytes>(withLogPrefix(lengthPrefixed(raw)), 'log')).toEqual(asBytes(raw))
+  })
+
+  test('string', () => {
+    const raw = encodingUtil.utf8ToUint8Array('hello')
+    expect(decodeArc4<string>(withLogPrefix(lengthPrefixed(raw)), 'log')).toEqual('hello')
+  })
+
+  test('Account', () => {
+    const raw = Bytes.fromHex(`${'00'.repeat(31)}ff`)
+    expect(decodeArc4<Account>(withLogPrefix(raw), 'log')).toEqual(raw)
+  })
+
+  test('Application', () => {
+    const raw = encodingUtil.bigIntToUint8Array(234234n, 8)
+    expect(decodeArc4<Application>(withLogPrefix(raw), 'log')).toEqual(234234)
+  })
+
+  test('Asset', () => {
+    const raw = encodingUtil.bigIntToUint8Array(234234n, 8)
+    expect(decodeArc4<Asset>(withLogPrefix(raw), 'log')).toEqual(234234)
+  })
+
+  test('throws when prefix=log but prefix is missing', () => {
+    const raw = asBytes(encodingUtil.bigIntToUint8Array(234234n, 8))
+    expect(() => decodeArc4<uint64>(raw, 'log')).toThrowError('ABI return prefix not found')
   })
 })
 

--- a/tests/pure-op-codes.algo.spec.ts
+++ b/tests/pure-op-codes.algo.spec.ts
@@ -702,7 +702,7 @@ describe('Pure op codes', async () => {
       await expect(getAvmResult<uint64>({ appClient }, 'verify_getbyte', asUint8Array(a as bytes), b as number)).rejects.toThrow(
         'getbyte index beyond array length',
       )
-      expect(() => op.getByte(a as bytes, b as number)).toThrow(/getBytes index \d+ is beyond length/)
+      expect(() => op.getByte(a as bytes, b as number)).toThrow(`getByte index ${b} is beyond length`)
     })
   })
 

--- a/tests/pure-op-codes.algo.spec.ts
+++ b/tests/pure-op-codes.algo.spec.ts
@@ -896,7 +896,7 @@ describe('Pure op codes', async () => {
       await expect(
         getAvmResultRaw({ appClient }, 'verify_setbit_bytes', asUint8Array(a as bytes), b as number, c as number),
       ).rejects.toThrow('setbit index beyond byteslice')
-      expect(() => op.setBit(a as bytes, b as number, c as number)).toThrow(/setBit index \d+ is beyond length/)
+      expect(() => op.setBit(a as bytes, b as number, c as number)).toThrow(`setBit index ${b} is beyond length`)
     })
 
     test('should throw error when input is invalid', async ({ appClientMiscellaneousOpsContract: appClient }) => {

--- a/tests/state-op-codes.algo.spec.ts
+++ b/tests/state-op-codes.algo.spec.ts
@@ -14,14 +14,14 @@ import { BytesCls, Uint64Cls } from '../src/impl/primitives'
 import { AccountCls, encodeAddress } from '../src/impl/reference'
 import type { ApplicationCallTransaction } from '../src/impl/transactions'
 import type { DeliberateAny, FunctionKeys } from '../src/typescript-helpers'
-import { asBigInt, asNumber, asUint64Cls, asUint8Array, getRandomBytes } from '../src/util'
+import { asNumber, asUint64BigInt, asUint64Cls, asUint8Array, getRandomBytes } from '../src/util'
 import { AppExpectingEffects } from './artifacts/created-app-asset/contract.algo'
 import {
   BoxMapContract,
   GlobalMapContract,
-  LocalMapContract,
   ItxnDemoContract,
   ITxnOpsContract,
+  LocalMapContract,
   StateAcctParamsGetContract,
   StateAppGlobalContract,
   StateAppGlobalExContract,
@@ -598,7 +598,7 @@ describe('State op codes', async () => {
       const bytesResult = contract.verify_get_bytes(Bytes(bytesKey))
       const uint64Result = contract.verify_get_uint64(Bytes(uint64Key))
       expect(bytesResult).toEqual(bytesAvmResult)
-      expect(asBigInt(uint64Result)).toEqual(uint64AvmResult)
+      expect(asUint64BigInt(uint64Result)).toEqual(uint64AvmResult)
 
       // delete
       await getAvmResult({ appClient }, 'verify_delete', asUint8Array(bytesKey))
@@ -611,7 +611,7 @@ describe('State op codes', async () => {
 
       const uint64AvmResult2 = await getAvmResult({ appClient }, 'verify_get_uint64', asUint8Array(uint64Key))
       const uint64Result2 = contract.verify_get_uint64(Bytes(uint64Key))
-      expect(asBigInt(uint64Result2)).toEqual(uint64AvmResult2)
+      expect(asUint64BigInt(uint64Result2)).toEqual(uint64AvmResult2)
     })
 
     test('should be able to use _ex methods to get state of another app', async ({
@@ -692,7 +692,7 @@ describe('State op codes', async () => {
       const bytesResult = contract.verify_get_bytes(account, Bytes(bytesKey))
       const uint64Result = contract.verify_get_uint64(account, Bytes(uint64Key))
       expect(bytesResult).toEqual(bytesAvmResult)
-      expect(asBigInt(uint64Result)).toEqual(uint64AvmResult)
+      expect(asUint64BigInt(uint64Result)).toEqual(uint64AvmResult)
 
       // delete
       await getAvmResult({ appClient }, 'verify_delete', localNetAccount.addr.toString(), asUint8Array(bytesKey))
@@ -712,7 +712,7 @@ describe('State op codes', async () => {
         asUint8Array(uint64Key),
       )
       const uint64Result2 = contract.verify_get_uint64(account, Bytes(uint64Key))
-      expect(asBigInt(uint64Result2)).toEqual(uint64AvmResult2)
+      expect(asUint64BigInt(uint64Result2)).toEqual(uint64AvmResult2)
     })
 
     test('should be able to use _ex methods to get state of another app', async ({


### PR DESCRIPTION
- test: cover decodeArc4 with log prefix for native types         
- refactor: tighten types and replace non-null assertions         
- refactor: remove dead code and visitor wrapper classes         
- refactor: extract DRY helpers across primitives, encoded-types and util         
- fix: assorted correctness bugs         
- fix: correct typos and naming inconsistencies         
- chore: rename appendInnerTransactionGroup to appendInnerTransaction         
- refactor: store compiled apps and logicsigs as Map         
- chore: rename asBigInt to asUint64BigInt
