### PR TITLE
chore: remove todo comments

### DIFF
--- a/examples/voting/contract.algo.ts
+++ b/examples/voting/contract.algo.ts
@@ -35,7 +35,6 @@ const BOX_BYTE_MIN_BALANCE: uint64 = 400
 // The min balance increase for each asset opted into
 const ASSET_MIN_BALANCE: uint64 = 100000
 
-// TODO: ObjectPType should hopefully respect this ordering of properties
 type VotingPreconditions = {
   is_voting_open: uint64
   is_allowed_to_vote: uint64

--- a/src/set-up.ts
+++ b/src/set-up.ts
@@ -145,7 +145,7 @@ function doAddEqualityTesters(expectObj: ExpectObj) {
     function AccountIsAccount(this: TesterContext, subject, test, customTesters): boolean | undefined {
       if (subject instanceof AccountCls) {
         const testValue = test instanceof AccountCls ? test : undefined
-        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
+        if (testValue !== undefined) return this.equals(subject.bytes, testValue.bytes, customTesters)
         return undefined
       }
       // Defer to other testers
@@ -154,7 +154,7 @@ function doAddEqualityTesters(expectObj: ExpectObj) {
     function ApplicationIsApplication(this: TesterContext, subject, test, customTesters): boolean | undefined {
       if (subject instanceof ApplicationCls) {
         const testValue = test instanceof ApplicationCls ? test : undefined
-        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
+        if (testValue !== undefined) return this.equals(subject.id, testValue.id, customTesters)
         return undefined
       }
       // Defer to other testers
@@ -163,7 +163,7 @@ function doAddEqualityTesters(expectObj: ExpectObj) {
     function AssetIsAsset(this: TesterContext, subject, test, customTesters): boolean | undefined {
       if (subject instanceof AssetCls) {
         const testValue = test instanceof AssetCls ? test : undefined
-        if (testValue !== undefined) return this.equals(subject['data'], testValue['data'], customTesters)
+        if (testValue !== undefined) return this.equals(subject.id, testValue.id, customTesters)
         return undefined
       }
       // Defer to other testers

--- a/src/subcontexts/contract-context.ts
+++ b/src/subcontexts/contract-context.ts
@@ -199,7 +199,6 @@ export class ContractContext {
     const appTxn = lazyContext.any.txn.applicationCall({
       appId: app,
       ...appCallArgs,
-      // TODO: This needs to be specifiable by the test code
       onCompletion: OnCompleteAction[(abiMetadata?.allowActions ?? [])[0]],
     })
     const txns = [...transactions, appTxn]

--- a/tests/artifacts/arc4-primitive-ops/contract.algo.ts
+++ b/tests/artifacts/arc4-primitive-ops/contract.algo.ts
@@ -368,7 +368,6 @@ export class Arc4PrimitiveOpsContract extends Contract {
     return convertBytes<Bool>(a, { prefix: 'log', strategy: 'unsafe-cast' })
   }
 
-  // TODO: recompile when puya-ts is updated
   @arc4.abimethod()
   public verify_emit(
     a: arc4.Str,

--- a/tests/reference-equality-testers.spec.ts
+++ b/tests/reference-equality-testers.spec.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { Account, Application, Asset } from '../src/impl/reference'
+import { TestExecutionContext } from '../src/test-execution-context'
+
+describe('Reference equality testers', () => {
+  const ctx = new TestExecutionContext()
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  it('test account equality', () => {
+    const account1 = ctx.any.account()
+    const account2 = ctx.any.account()
+
+    expect(account1).not.toEqual(account2)
+
+    const sameAddr = Account(account1.bytes)
+    expect(account1).toEqual(sameAddr)
+  })
+
+  it('test application equality', () => {
+    const app1 = ctx.any.application()
+    const app2 = ctx.any.application()
+
+    expect(app1).not.toEqual(app2)
+
+    const sameId = Application(app1.id)
+    expect(app1).toEqual(sameId)
+  })
+
+  it('test asset equality', () => {
+    const asset1 = ctx.any.asset()
+    const asset2 = ctx.any.asset()
+
+    expect(asset1).not.toEqual(asset2)
+
+    const sameId = Asset(asset1.id)
+    expect(asset1).toEqual(sameId)
+  })
+})

--- a/tests/test-fixture.ts
+++ b/tests/test-fixture.ts
@@ -123,14 +123,36 @@ export function createBaseTestFixture<TContracts extends string = ''>(options: {
             onComplete: options?.onComplete ?? OnApplicationComplete.NoOpOC,
             sender: options?.sender ?? localnet.context.testAccount.addr,
           }
-          if (common.appId === 0n || common.onComplete === OnApplicationComplete.UpdateApplicationOC) {
-            common.approvalProgram = approvalProgram
-            common.clearStateProgram = clearStateProgram
-          }
           const group = localnet.algorand.send.newGroup()
-          group.addAppCall(common as DeliberateAny)
-
-          // TODO: Add simulate call to gather trace
+          if (common.appId === 0n) {
+            invariant(common.onComplete !== OnApplicationComplete.UpdateApplicationOC, 'Cannot update appId 0')
+            invariant(common.onComplete !== OnApplicationComplete.ClearStateOC, 'Cannot clear state of appId 0')
+            const { appId, ...rest } = common
+            group.addAppCreate({
+              ...rest,
+              onComplete: common?.onComplete ?? OnApplicationComplete.NoOpOC,
+              approvalProgram,
+              clearStateProgram,
+              schema: {
+                localInts: options?.schema?.localInts ?? 0,
+                localByteSlices: options?.schema?.localByteSlices ?? 0,
+                globalInts: options?.schema?.globalInts ?? 0,
+                globalByteSlices: options?.schema?.globalByteSlices ?? 0,
+              },
+            })
+          } else if (common.onComplete === OnApplicationComplete.UpdateApplicationOC) {
+            group.addAppUpdate({
+              ...common,
+              onComplete: OnApplicationComplete.UpdateApplicationOC,
+              approvalProgram,
+              clearStateProgram,
+            })
+          } else {
+            group.addAppCall({
+              ...common,
+              onComplete: common?.onComplete ?? OnApplicationComplete.NoOpOC,
+            })
+          }
 
           const result = await group.send()
           return {

--- a/tests/test-fixture.ts
+++ b/tests/test-fixture.ts
@@ -6,7 +6,7 @@ import type { SendAppTransactionResult } from '@algorandfoundation/algokit-utils
 import type { Arc56Contract } from '@algorandfoundation/algokit-utils/types/app-arc56'
 import type { AppClient } from '@algorandfoundation/algokit-utils/types/app-client'
 import type { AppFactory, AppFactoryDeployParams } from '@algorandfoundation/algokit-utils/types/app-factory'
-import type { AssetCreateParams } from '@algorandfoundation/algokit-utils/types/composer'
+import type { AppCallParams, AppUpdateParams, AssetCreateParams } from '@algorandfoundation/algokit-utils/types/composer'
 import { nullLogger } from '@algorandfoundation/algokit-utils/types/logging'
 import type { AlgorandFixture } from '@algorandfoundation/algokit-utils/types/testing'
 import { compile, CompileOptions, LoggingContext, processInputPaths } from '@algorandfoundation/puya-ts'
@@ -127,10 +127,10 @@ export function createBaseTestFixture<TContracts extends string = ''>(options: {
           if (common.appId === 0n) {
             invariant(common.onComplete !== OnApplicationComplete.UpdateApplicationOC, 'Cannot update appId 0')
             invariant(common.onComplete !== OnApplicationComplete.ClearStateOC, 'Cannot clear state of appId 0')
-            const { appId, ...rest } = common
+            const { appId: _, ...rest } = common
             group.addAppCreate({
               ...rest,
-              onComplete: common?.onComplete ?? OnApplicationComplete.NoOpOC,
+              onComplete: common.onComplete,
               approvalProgram,
               clearStateProgram,
               schema: {
@@ -141,17 +141,15 @@ export function createBaseTestFixture<TContracts extends string = ''>(options: {
               },
             })
           } else if (common.onComplete === OnApplicationComplete.UpdateApplicationOC) {
+            const { schema: _, ...rest } = common
             group.addAppUpdate({
-              ...common,
-              onComplete: OnApplicationComplete.UpdateApplicationOC,
+              ...rest,
               approvalProgram,
               clearStateProgram,
-            })
+            } as AppUpdateParams)
           } else {
-            group.addAppCall({
-              ...common,
-              onComplete: common?.onComplete ?? OnApplicationComplete.NoOpOC,
-            })
+            const { schema: _, ...rest } = common
+            group.addAppCall(rest as AppCallParams)
           }
 
           const result = await group.send()


### PR DESCRIPTION
*also*:
- fix equality testers for Account, Application and Asset objects.
- tidy up by removing extra casting, operators and spreads