### PR TITLE
chore: Fix release of beta versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
   release:
     name: Release
     needs: build
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token


### PR DESCRIPTION
`sucess()` is `false` whenever any step is skipped. This is because `success()` is not the same as `!failure()`.