### PR TITLE
chore: add min-release-age to .npmrc and audit-exception for brace-expansion

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/.nsprc
+++ b/.nsprc
@@ -6,5 +6,9 @@
   "GHSA-v2v4-37r5-5v8g": {
     "active": true,
     "notes": "XSS in Address6 HTML-emitting methods in ip-address. Transitive dependency via npm internals (npm > ip-address); not invoked in this project."
+  },
+  "GHSA-jxxr-4gwj-5jf2": {
+    "active": true,
+    "notes": "brace-expansion DoS via large numeric ranges. Transitive dev/build dependency via minimatch (eslint, typescript-eslint, puya-ts, semantic-release, npm); no user-controlled input is passed to brace-expansion in this project."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3563,9 +3563,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `min-release-age=7` so newly published package versions must be at least 7 days old before they can be installed. This blocks the typical window in which malicious npm releases are detected and yanked, mitigating exposure to fast-moving supply chain attacks. **Note:** `min-release-age` requires npm v11.10.0+, older npm versions silently ignore the directive.
- Add `GHSA-jxxr-4gwj-5jf2` (brace-expansion DoS via large numeric ranges) to `.nsprc`. It's a transitive dev/build dependency via `minimatch` (eslint, typescript-eslint, puya-ts, semantic-release, npm), no user-controlled input flows into it in this project.