### PR TITLE
ci: split release workflow into ci + build jobs to match algokit shared workflow inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,23 @@ jobs:
             exit 1
           fi
 
-  build:
-    name: Build
+  ci:
+    name: CI
     needs: check-puya-ts
     if: ${{ !failure() && !cancelled() }}
-    uses: algorandfoundation/algokit-shared-config/.github/workflows/node-build.yml@main
+    uses: algorandfoundation/algokit-shared-config/.github/workflows/node-ci.yml@main
     with:
       run-commit-lint: true
-      run-build: true
       install-algokit: true
       install-puyapy: true
       audit-script: npm run audit
+
+  build:
+    name: Build
+    needs: ci
+    if: ${{ !failure() && !cancelled() }}
+    uses: algorandfoundation/algokit-shared-config/.github/workflows/node-build.yml@main
+    with:
       build-path: dist
       artifact-name: algo-ts-testing
 


### PR DESCRIPTION
## Summary
`release.yml` was calling algokit-shared-config `node-build.yml@main` with inputs that only exist on `node-ci.yml`, causing GitHub to reject the workflow on merge.

Fix: split into two jobs: `ci` for lint/audit/commit-lint/tests with algokit + puyapy and `build` for `npm run build` + artifact upload.