### PR TITLE
ci: grant pages: write permission to publish_docs job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,4 +108,8 @@ jobs:
     name: Publish docs to GitHub Pages
     needs: release
     if: github.ref_name == 'release'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: algorandfoundation/algokit-shared-config/.github/workflows/publish-docs.yml@main


### PR DESCRIPTION
## Summary
The `publish_docs` job calls the reusable `publish-docs.yml` workflow which requires `pages: write`, but the calling workflow only granted `pages: none` (the default). GitHub validates reusable workflow permissions at parse time regardless of the job's `if:` guard, so this failed on every push to `main`/`alpha` even though the job is gated to the `release` branch.

Fix: add a job-level `permissions:` block on `publish_docs` granting `contents: read`, `pages: write`, and `id-token: write`, scoped to the job rather than the whole workflow (least privilege).