### PR TITLE
chore: harden workflows and retire alpha channel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - alpha
     paths-ignore:
       - 'scripts/**'
 

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -4,21 +4,21 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prod_release:
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
         run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
 
       - name: Merge main -> release
-        uses: devmasx/merge-branch@6ec8363d74aad4f1615d1234ae1908b4185c4313
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: main
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{ steps.app_token.outputs.token }}
 
       - name: Merge release -> main
-        uses: devmasx/merge-branch@6ec8363d74aad4f1615d1234ae1908b4185c4313
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0
         with:
           type: now
           from_branch: release

--- a/.github/workflows/publish-devportal-docs.yml
+++ b/.github/workflows/publish-devportal-docs.yml
@@ -3,23 +3,23 @@ name: Publish DevPortal Docs
 on:
   workflow_dispatch:
   push:
-    branches: [ci/add-publish-to-devportal-workflow] # change to main when ready
+    branches: [main]
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           package_json_file: docs/package.json
 
@@ -30,6 +30,6 @@ jobs:
         run: npm run build
 
       - name: Publish DevPortal Docs
-        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@ci/update-publish-devportal-docs-workflow
+        uses: algorandfoundation/devportal/.github/actions/publish-devportal-docs@release/ak-v4
         with:
           docs-dir: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Publish
 on:
   push:
     branches:
-      - alpha
       - main
       - release
   workflow_dispatch:
@@ -11,9 +10,7 @@ on:
 concurrency: release
 
 permissions:
-  contents: write
-  issues: read
-  id-token: write
+  contents: read
 
 jobs:
   check-puya-ts:
@@ -21,7 +18,7 @@ jobs:
     if: github.ref_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { fetch-depth: 1 }
       - name: Ensure puya-ts dependency is a production release
         run: |
@@ -64,29 +61,31 @@ jobs:
     needs: build
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Generate bot token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app_token
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
 
       - run: npm ci --ignore-scripts
 
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: algo-ts-testing
           path: artifacts/algo-ts-testing
@@ -97,12 +96,12 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Publish @algorandfoundation/algorand-typescript-testing
-        uses: JS-DevTools/npm-publish@v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
         with:
           package: artifacts/algo-ts-testing/package.json
           access: 'public'
           provenance: true
-          tag: ${{ github.ref_name == 'alpha' && 'alpha' || github.ref_name == 'main' && 'beta' || github.ref_name == 'release' && 'latest' || 'pre-release' }}
+          tag: ${{ github.ref_name == 'main' && 'beta' || github.ref_name == 'release' && 'latest' || 'pre-release' }}
 
   publish_docs:
     name: Publish docs to GitHub Pages

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,10 +6,6 @@
     },
     {
       "name": "release"
-    },
-    {
-      "name": "alpha",
-      "prerelease": "alpha"
     }
   ],
   "plugins": [


### PR DESCRIPTION
## Summary

This PR makes a few related CI/CD changes now that the `alpha` prerelease channel is being retired:

1. **Hardens the CI workflows** by pinning all third-party GitHub Actions to immutable commit SHAs and tightening workflow permissions to least-privilege.
2. **Removes leftover `alpha` branch references** across CI triggers, release config, and the npm dist-tag expression.
3. **Keeps the DevPortal docs current** by publishing the rolling `docs-latest` build on every push to `main`.

## Changes

### CI security hardening

- Pin all third-party actions to full commit SHAs (with `# vX` comments) instead of mutable tags in `pr.yml`, `prod-release.yml`, `publish-devportal-docs.yml`, and `release.yml`. First-party `algokit-shared-config` reusable workflows stay on `@main` per policy.
- Bump `pnpm/action-setup` from v4 to v6 (pinned to its SHA); the pnpm version is still resolved from `docs/package.json`'s `packageManager` field.
- Realign `devmasx/merge-branch` from an arbitrary readme-update commit pin to the `v1.4.0` tagged commit (SHA-pinned with a `# v1.4.0` comment).
- Narrow top-level `permissions` in `release.yml` from `contents: write` / `issues: read` / `id-token: write` down to `contents: read`, and in `prod-release.yml` and `publish-devportal-docs.yml` from `contents: write` to `contents: read`. The `release` job keeps a local `id-token: write` grant because `JS-DevTools/npm-publish` is invoked with `provenance: true` and needs an OIDC token to sign the npm provenance attestation.

### Branch cleanup

- Remove the `alpha` prerelease channel from PR trigger branches (`pr.yml`), release push branches (`release.yml`), and the semantic-release config in `.releaserc.json`.
- Drop the `github.ref_name == 'alpha' && 'alpha' ||` arm from the npm dist-tag expression in `release.yml` so the publish step no longer references the retired channel.
- Update `publish-devportal-docs.yml`: drop the temporary `ci/add-publish-to-devportal-workflow` push trigger and point the publish action at `release/ak-v4`.

### DevPortal docs publishing

- Add a `push: branches: [main]` trigger to `publish-devportal-docs.yml` so the rolling `docs-latest` pre-release is refreshed on every merge to `main`. Tag pushes (`v*`) continue to attach `devportal-docs.tar.gz` to the corresponding version release.

## Why

- Pinning actions to SHAs protects the supply chain against tag-retargeting attacks.
- Least-privilege permissions reduce the blast radius if a workflow or dependency is compromised.
- The `alpha` prerelease channel is being retired, so its triggers, dist-tag arm, and release config are removed to stop further `*-alpha.*` publishes and CI runs on that branch.
- The DevPortal imports each library's "Latest" docs from the `docs-latest` release, which is only refreshed by non-tag runs. Without a `main` trigger, `docs-latest` would go stale and the portal would keep serving outdated docs.